### PR TITLE
Development of altBkg fits with MC templates

### DIFF
--- a/create_totBkg_file.py
+++ b/create_totBkg_file.py
@@ -1,0 +1,127 @@
+import ROOT
+
+lumi_data = 16.8  # fb^-1, for 2016postVFP
+
+BR_TAUToMU = 0.1739
+BR_TAUToE = 0.1782
+Z_TAU_TO_LEP_RATIO = (1.-(1. - BR_TAUToMU - BR_TAUToE)**2)
+xsec_ZmmPostVFP = 2001.9
+
+cross_sections_bkg = {
+    # Unit = pb
+    "QCD" : 238800,
+    "WW" : 12.6,
+    "WZ" : 27.59,  #5.4341,
+    "ZZ" : 0.60,
+    "TTFullyleptonic" : 88.29,
+    "TTSemileptonic" : 366.34,
+    "WplusJets" : 11765.9,
+    "WminusJets" : 8703.87,
+    "Ztautau" : xsec_ZmmPostVFP*Z_TAU_TO_LEP_RATIO,
+    "Zjets" : xsec_ZmmPostVFP  # obtained from the signal MC file with the "reverse" gen-matching option
+}
+
+def lumi_factor(filepath, process):
+    """
+    Returns the lumi factor for the process in the given file
+    """
+    file = ROOT.TFile(filepath)
+    wsum_histo = file.Get("weightSum")
+    num_init = wsum_histo.Integral()
+
+    if "mc" in filepath:
+        xsection = xsec_ZmmPostVFP*1000 # has to be put in fb
+    else:
+        xsection = cross_sections_bkg[process]*1000
+        
+    lumi_process = num_init/xsection
+
+    scale = lumi_data/lumi_process
+
+    return scale
+
+
+def checkAddConsistency(sum, h_list):
+    for i in range(1, (sum.GetNbinsX()*sum.GetNbinsY()*sum.GetNbinsZ())+1):
+        external_sum = 0
+        for h in h_list:
+            external_sum += h.GetBinContent(i)
+        internal_sum = sum.GetBinContent(i)
+        if external_sum != internal_sum:
+            print("UNCORRECT SUM FOR BIN", i)
+
+
+
+
+if __name__ == "__main__":
+
+
+    old_Steve_version = True
+
+    eff_type = "recoplus"
+
+    base_folder = f"/home/rforti/egm_tnp_analysis/steve_histograms_2016/{eff_type.replace('plus', '').replace('minus', '')}/"
+
+    bkg_types = ["WW", "WZ", "ZZ", "TTSemileptonic", "TTFullyleptonic", "Ztautau", "WplusJets", "WminusJets", 
+                 #"QCD", 
+                 "Zjets"]
+
+    if old_Steve_version:
+        bkg_types.remove("Zjets")
+        bkg_types += ["mc"]
+
+    files = [base_folder+f"tnp_{eff_type}_{bkg_type}_vertexWeights1_genMatching0_oscharge1.root" for bkg_type in bkg_types]
+
+
+    if old_Steve_version:
+        files = [file.replace("genMatching0", "genMatching-1") if "_mc_" in file else file for file in files]
+    else:
+        files = [file.replace("_genMatching0_", "") for file in files]
+
+
+    file_out = ROOT.TFile(f"{base_folder}tnp_{eff_type}_bkg_vertexWeights1_genMatching0_oscharge1.root", "recreate")
+
+
+
+    for fl in ["pass", "fail"]:
+        
+        rootfiles = []
+        histos = []
+
+        for file in files:
+            # print("Opening file", file)
+            rootfiles.append(ROOT.TFile(file, "read"))
+        
+        for rf in rootfiles:
+            histos.append(rf.Get(f"{fl}_mu_DY_postVFP"))
+            if old_Steve_version:
+                # print(rf.GetName())
+                bkg_process = rf.GetName().split("/")[-1].split("_")[2]
+                if bkg_process == "mc": bkg_process = "Zjets"
+                histos[-1].Scale(lumi_factor(rf.GetName(), bkg_process))
+                # print(f"Scaling {bkg_process} by {lumi_factor(rf.GetName(), bkg_process)}")
+
+        hist_sum = histos[0].Clone(f"{fl}_mu_DY_postVFP")
+        print(hist_sum.Integral())
+        hist_sum.Reset()
+        print(hist_sum.Integral())
+
+        for h in histos:
+            hist_sum.Add(h)
+
+        checkAddConsistency(hist_sum, histos)
+
+
+        file_out.cd()
+        hist_sum.Write()
+
+        external_sum = 0
+        for h in histos:
+            external_sum += h.Integral()
+
+        print(hist_sum.Integral(), external_sum)
+
+        
+
+    file_out.Close()
+

--- a/create_totBkg_file.py
+++ b/create_totBkg_file.py
@@ -1,4 +1,5 @@
 import ROOT
+import argparse
 
 lumi_data = 16.8  # fb^-1, for 2016postVFP
 
@@ -21,6 +22,70 @@ cross_sections_bkg = {
     "Zjets" : xsec_ZmmPostVFP  # obtained from the signal MC file with the "reverse" gen-matching option
 }
 
+working_points_global = {
+    ## for global muons
+    ##
+    #'mu_reco_both': ['/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_reco_mc_vertexWeights1_oscharge1.root',
+    #                 '/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_reco_data_vertexWeights1_oscharge1.root'],
+    'mu_reco_plus': ['/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_recoplus_mc_vertexWeights1_oscharge1.root',
+                     '/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_recoplus_data_vertexWeights1_oscharge1.root'],
+    'mu_reco_minus': ['/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_recominus_mc_vertexWeights1_oscharge1.root',
+                      '/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_recominus_data_vertexWeights1_oscharge1.root'],
+    # 'mu_reco_minusodd': ['/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_recominusodd_mc_vertexWeights1_oscharge1.root',
+    #                  '/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_recominusodd_data_vertexWeights1_oscharge1.root'],
+    # 'mu_reco_minuseven': ['/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_recominuseven_mc_vertexWeights1_oscharge1.root',
+    #                  '/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_recominuseven_data_vertexWeights1_oscharge1.root'],
+    'mu_tracking_both': ['/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_tracking_mc_vertexWeights1_oscharge0.root',
+                         '/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_tracking_data_vertexWeights1_oscharge0.root'],
+    'mu_tracking_plus': ['/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_tracking_mc_vertexWeights1_oscharge0_tagChargeMinus.root',
+                             '/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_tracking_data_vertexWeights1_oscharge0_tagChargeMinus.root'],
+    'mu_tracking_minus': ['/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_tracking_mc_vertexWeights1_oscharge0_tagChargePlus.root',
+                            '/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_tracking_data_vertexWeights1_oscharge0_tagChargePlus.root'],
+    # 'mu_tracking_odd': ['/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_trackingodd_mc_vertexWeights1_oscharge0.root',
+    #                      '/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_trackingodd_data_vertexWeights1_oscharge0.root'],
+    # 'mu_tracking_even': ['/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_trackingeven_mc_vertexWeights1_oscharge0.root',
+    #                      '/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_trackingeven_data_vertexWeights1_oscharge0.root'],
+    'mu_idip_both': ['/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_idip_mc_vertexWeights1_oscharge1.root',
+                     '/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_idip_data_vertexWeights1_oscharge1.root'],
+    'mu_idip_plus': ['/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_idipplus_mc_vertexWeights1_oscharge1.root',
+                     '/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_idipplus_data_vertexWeights1_oscharge1.root'],
+    'mu_idip_minus': ['/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_idipminus_mc_vertexWeights1_oscharge1.root',
+                      '/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_idipminus_data_vertexWeights1_oscharge1.root'],
+    'mu_trigger_plus': ['/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_triggerplus_mc_vertexWeights1_oscharge1.root',
+                        '/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_triggerplus_data_vertexWeights1_oscharge1.root'],
+    'mu_trigger_minus': ['/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_triggerminus_mc_vertexWeights1_oscharge1.root',
+                         '/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_triggerminus_data_vertexWeights1_oscharge1.root'],
+    'mu_iso_both': ['/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_iso_mc_vertexWeights1_oscharge1.root',
+                    '/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_iso_data_vertexWeights1_oscharge1.root'],
+    # 'mu_iso_plus': ['/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_isoplus_mc_vertexWeights1_oscharge1.root',
+    #                 '/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_isoplus_data_vertexWeights1_oscharge1.root'],
+    # 'mu_iso_minus': ['/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_isominus_mc_vertexWeights1_oscharge1.root',
+    #                 '/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_isominus_data_vertexWeights1_oscharge1.root'],
+    'mu_isonotrig_both': ['/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_isonotrig_mc_vertexWeights1_oscharge1.root',
+                          '/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_isonotrig_data_vertexWeights1_oscharge1.root'],
+    'mu_veto_both': ['/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_veto_mc_vertexWeights1_oscharge1.root',
+                     '/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_veto_data_vertexWeights1_oscharge1.root'],
+}
+
+working_points_new = {
+    'mu_reco_plus': ['/scratch/rforti/steve_histograms_2016/reco/tnp_recoplus_mc_vertexWeights1_genMatching1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2016/reco/tnp_recoplus_data_vertexWeights1_genMatching1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2016/reco/tnp_recoplus_bkg_vertexWeights1_genMatching0_oscharge1.root'],
+    'mu_reco_minus': ['/scratch/rforti/steve_histograms_2016/reco/tnp_recominus_mc_vertexWeights1_genMatching1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2016/reco/tnp_recominus_data_vertexWeights1_genMatching1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2016/reco/tnp_recominus_bkg_vertexWeights1_genMatching0_oscharge1.root'],
+    'mu_tracking_plus': ['/scratch/rforti/steve_histograms_2016/tracking/tnp_trackingplus_mc_vertexWeights1_genMatching1_oscharge0.root',
+                         '/scratch/rforti/steve_histograms_2016/tracking/tnp_trackingplus_data_vertexWeights1_genMatching1_oscharge0.root',
+                         '/scratch/rforti/steve_histograms_2016/tracking/tnp_trackingplus_bkg_vertexWeights1_genMatching0_oscharge0.root'],
+    'mu_tracking_minus': ['/scratch/rforti/steve_histograms_2016/tracking/tnp_trackingminus_mc_vertexWeights1_genMatching1_oscharge0.root',
+                          '/scratch/rforti/steve_histograms_2016/tracking/tnp_trackingminus_data_vertexWeights1_genMatching1_oscharge0.root',
+                          '/scratch/rforti/steve_histograms_2016/tracking/tnp_trackingminus_bkg_vertexWeights1_genMatching0_oscharge0.root'],
+}
+
+bkg_types = ["WW", "WZ", "ZZ", "TTSemileptonic", "TTFullyleptonic", "Ztautau", "WplusJets", "WminusJets", 
+             #"QCD", 
+             "Zjets"]
+
 def lumi_factor(filepath, process):
     """
     Returns the lumi factor for the process in the given file
@@ -28,16 +93,12 @@ def lumi_factor(filepath, process):
     file = ROOT.TFile(filepath)
     wsum_histo = file.Get("weightSum")
     num_init = wsum_histo.Integral()
-
-    if "mc" in filepath:
+    if "mc" in filepath: 
         xsection = xsec_ZmmPostVFP*1000 # has to be put in fb
     else:
         xsection = cross_sections_bkg[process]*1000
-        
     lumi_process = num_init/xsection
-
     scale = lumi_data/lumi_process
-
     return scale
 
 
@@ -51,76 +112,76 @@ def checkAddConsistency(sum, h_list):
             print("INCORRECT SUM FOR BIN", i)
 
 
+parser = argparse.ArgumentParser()
+parser.add_argument('-s','--steps', default=None, nargs='*', type=str, choices=list([x.split("_")[1] for x in working_points_global.keys()]),
+                    help='Default runs all working points, but can choose only some if needed')
+parser.add_argument('-x','--exclude', default=None, nargs='*', type=str, choices=list([x.split("_")[1] for x in working_points_global.keys()]),
+                    help='Default runs all working points, but can exclude some if needed')
+parser.add_argument('--oldSteve', action='store_true',
+                    help='Use input files from Steve that have the "old" naming scheme (i.e. with the "genMatching" flag)')
+                    
+args = parser.parse_args()
+                    
+          
+if args.oldSteve is True: 
+    bkg_types.remove("Zjets") 
+    bkg_types += ["mc"]
+    datasets = working_points_new
+else:
+    datasets = working_points_global
 
-
-if __name__ == "__main__":
-
-
-    old_Steve_version = True
-
-    eff_type = "recoplus"
-
-    base_folder = f"/scratch/rforti/steve_histograms_2016/{eff_type.replace('plus', '').replace('minus', '')}/"
-
-    bkg_types = ["WW", "WZ", "ZZ", "TTSemileptonic", "TTFullyleptonic", "Ztautau", "WplusJets", "WminusJets", "QCD", "Zjets"]
-
-    if old_Steve_version:
-        bkg_types.remove("Zjets")
-        bkg_types += ["mc"]
-
-    files = [base_folder+f"tnp_{eff_type}_{bkg_type}_vertexWeights1_genMatching0_oscharge1.root" for bkg_type in bkg_types]
-
-
-    if old_Steve_version:
-        files = [file.replace("genMatching0", "genMatching-1") if "_mc_" in file else file for file in files]
-    else:
-        files = [file.replace("_genMatching0_", "") for file in files]
-
-
-    file_out = ROOT.TFile(f"{base_folder}tnp_{eff_type}_bkg_vertexWeights1_genMatching0_oscharge1.root", "recreate")
-
-
-
-    for fl in ["pass", "fail"]:
+for eff in args.steps:
+    for ch in ["plus", "minus"]:
+    
+        if not f"mu_{eff}_{ch}" in datasets.keys(): 
+            continue
+        else:
+            base_folder = datasets[f"mu_{eff}_{ch}"][0].replace(datasets[f"mu_{eff}_{ch}"][0].split("/")[-1], "")
+            
+        os = 1 if eff!="tracking" else 0
         
-        rootfiles = []
-        histos = []
-
-        for file in files:
-            # print("Opening file", file)
-            rootfiles.append(ROOT.TFile(file, "read"))
+        print(bkg_types)
         
-        for rf in rootfiles:
-            histos.append(rf.Get(f"{fl}_mu_DY_postVFP"))
-            if old_Steve_version:
-                # print(rf.GetName())
-                bkg_process = rf.GetName().split("/")[-1].split("_")[2]
-                if bkg_process == "mc": bkg_process = "Zjets"
+        fnames = [base_folder+f"tnp_{eff}{ch}_{bkg_type}_vertexWeights1_genMatching0_oscharge{os}.root" for bkg_type in bkg_types]
+        
+        if args.oldSteve:
+            fnames = [fname.replace("genMatching0", "genMatching-1") if "_mc_" in fname else fname for fname in fnames]
+        else:
+            fnames = [fname.replace("_genMatching0_", "") for fname in fnames]
+
+        if len(datasets[f"mu_{eff}_{ch}"])==3:    
+            file_out = ROOT.TFile(datasets[f"mu_{eff}_{ch}"][2], "RECREATE")
+        else:
+            file_out = ROOT.TFile(f"{base_folder}tnp_{eff}{ch}_bkg_vertexWeights1_genMatching0_oscharge{os}.root", "RECREATE")
+
+
+
+
+        for fl in ["pass", "fail"]:
+
+            rootfiles = []
+            histos = []
+
+            for fname in fnames: rootfiles.append(ROOT.TFile(fname, "read"))
+
+            for rf in rootfiles:
+                histos.append(rf.Get(f"{fl}_mu_DY_postVFP"))
+                if args.oldSteve:
+                    bkg_process = rf.GetName().split("/")[-1].split("_")[2]
+                    if bkg_process == "mc": bkg_process = "Zjets"
                 histos[-1].Scale(lumi_factor(rf.GetName(), bkg_process))
-                # print(f"Scaling {bkg_process} by {lumi_factor(rf.GetName(), bkg_process)}")
+                print(f"Scaling {bkg_process} by {lumi_factor(rf.GetName(), bkg_process)}")
 
-        hist_sum = histos[0].Clone(f"{fl}_mu_DY_postVFP")
-        print(hist_sum.Integral())
-        hist_sum.Reset()
-        print(hist_sum.Integral())
-        hist_sum.SetName(f"{fl}_mu_mcBkg_postVFP")
-        hist_sum.SetTitle(f"{fl}_mu_mcBkg_postVFP")
-        for h in histos:
-            hist_sum.Add(h)
+            hist_sum = histos[0].Clone(f"{fl}_mu_DY_postVFP")
+            hist_sum.Reset()
+            hist_sum.SetName(f"{fl}_mu_mcBkg_postVFP"), hist_sum.SetTitle(f"{fl}_mu_mcBkg_postVFP")
+            for h in histos:
+                hist_sum.Add(h)
 
-        checkAddConsistency(hist_sum, histos)
+            checkAddConsistency(hist_sum, histos)
 
+            file_out.cd()
+            hist_sum.Write()
 
-        file_out.cd()
-        hist_sum.Write()
-
-        external_sum = 0
-        for h in histos:
-            external_sum += h.Integral()
-
-        print(hist_sum.Integral(), external_sum)
-
-        
-
-    file_out.Close()
+        file_out.Close()
 

--- a/create_totBkg_file.py
+++ b/create_totBkg_file.py
@@ -197,7 +197,7 @@ if args.oldSteve is True:
     bkg_types += ["mc"]
     datasets = working_points_new
     args.scale_bkg_by_lumi = True
-elif args.year=="2017:
+elif args.year=="2017":
     datasets = working_points_2017
 elif args.year=="2018":
     datasets = working_points_2018

--- a/create_totBkg_file.py
+++ b/create_totBkg_file.py
@@ -48,7 +48,7 @@ def checkAddConsistency(sum, h_list):
             external_sum += h.GetBinContent(i)
         internal_sum = sum.GetBinContent(i)
         if external_sum != internal_sum:
-            print("UNCORRECT SUM FOR BIN", i)
+            print("INCORRECT SUM FOR BIN", i)
 
 
 
@@ -60,11 +60,9 @@ if __name__ == "__main__":
 
     eff_type = "recoplus"
 
-    base_folder = f"/home/rforti/egm_tnp_analysis/steve_histograms_2016/{eff_type.replace('plus', '').replace('minus', '')}/"
+    base_folder = f"/scratch/rforti/steve_histograms_2016/{eff_type.replace('plus', '').replace('minus', '')}/"
 
-    bkg_types = ["WW", "WZ", "ZZ", "TTSemileptonic", "TTFullyleptonic", "Ztautau", "WplusJets", "WminusJets", 
-                 #"QCD", 
-                 "Zjets"]
+    bkg_types = ["WW", "WZ", "ZZ", "TTSemileptonic", "TTFullyleptonic", "Ztautau", "WplusJets", "WminusJets", "QCD", "Zjets"]
 
     if old_Steve_version:
         bkg_types.remove("Zjets")
@@ -105,7 +103,8 @@ if __name__ == "__main__":
         print(hist_sum.Integral())
         hist_sum.Reset()
         print(hist_sum.Integral())
-
+        hist_sum.SetName(f"{fl}_mu_mcBkg_postVFP")
+        hist_sum.SetTitle(f"{fl}_mu_mcBkg_postVFP")
         for h in histos:
             hist_sum.Add(h)
 

--- a/create_totBkg_file.py
+++ b/create_totBkg_file.py
@@ -1,7 +1,10 @@
 import ROOT
+import sys
 import argparse
 
-lumi_data = 16.8  # fb^-1, for 2016postVFP
+lumi_data = {"2016" : 16.8, # only postVFP
+             "2017" : 37.99, # this includes the LS where the HLT_isoMu24 was not prescaled
+             "2018" : 59.81}
 
 BR_TAUToMU = 0.1739
 BR_TAUToE = 0.1782
@@ -67,6 +70,69 @@ working_points_global = {
                      '/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_veto_data_vertexWeights1_oscharge1.root'],
 }
 
+working_points_2017 = {
+    'mu_reco_plus': ['/scratch/rforti/steve_histograms_2017/tnp_recoplus_mc_vertexWeights1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2017/tnp_recoplus_data_vertexWeights1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2017/tnp_recoplus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_reco_minus': ['/scratch/rforti/steve_histograms_2017/tnp_recominus_mc_vertexWeights1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2017/tnp_recominus_data_vertexWeights1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2017/tnp_recominus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_tracking_plus': ['/scratch/rforti/steve_histograms_2017/tnp_trackingplus_mc_vertexWeights1_oscharge0.root',
+                         '/scratch/rforti/steve_histograms_2017/tnp_trackingplus_data_vertexWeights1_oscharge0.root',
+                         '/scratch/rforti/steve_histograms_2017/tnp_trackingplus_bkg_vertexWeights1_oscharge0.root'],
+    'mu_tracking_minus': ['/scratch/rforti/steve_histograms_2017/tnp_trackingminus_mc_vertexWeights1_oscharge0.root',
+                          '/scratch/rforti/steve_histograms_2017/tnp_trackingminus_data_vertexWeights1_oscharge0.root',
+                          '/scratch/rforti/steve_histograms_2017/tnp_trackingminus_bkg_vertexWeights1_oscharge0.root'],
+    'mu_idip_plus': ['/scratch/rforti/steve_histograms_2017/tnp_idipplus_mc_vertexWeights1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2017/tnp_idipplus_data_vertexWeights1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2017/tnp_idipplus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_idip_minus': ['/scratch/rforti/steve_histograms_2017/tnp_idipminus_mc_vertexWeights1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2017/tnp_idipminus_data_vertexWeights1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2017/tnp_idipminus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_trigger_plus': ['/scratch/rforti/steve_histograms_2017/tnp_triggerplus_mc_vertexWeights1_oscharge1.root',
+                        '/scratch/rforti/steve_histograms_2017/tnp_triggerplus_data_vertexWeights1_oscharge1.root',
+                        '/scratch/rforti/steve_histograms_2017/tnp_triggerplus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_trigger_minus': ['/scratch/rforti/steve_histograms_2017/tnp_triggerminus_mc_vertexWeights1_oscharge1.root',
+                         '/scratch/rforti/steve_histograms_2017/tnp_triggerminus_data_vertexWeights1_oscharge1.root',
+                         '/scratch/rforti/steve_histograms_2017/tnp_triggerminus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_iso_both': ['/scratch/rforti/steve_histograms_2017/tnp_iso_mc_vertexWeights1_oscharge1.root',
+                    '/scratch/rforti/steve_histograms_2017/tnp_iso_data_vertexWeights1_oscharge1.root',
+                    '/scratch/rforti/steve_histograms_2017/tnp_iso_bkg_vertexWeights1_oscharge1.root'],
+}
+
+
+working_points_2018 = {
+
+    'mu_reco_plus': ['/scratch/rforti/steve_histograms_2018/tnp_recoplus_mc_vertexWeights1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2018/tnp_recoplus_data_vertexWeights1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2018/tnp_recoplus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_reco_minus': ['/scratch/rforti/steve_histograms_2018/tnp_recominus_mc_vertexWeights1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2018/tnp_recominus_data_vertexWeights1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2018/tnp_recominus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_tracking_plus': ['/scratch/rforti/steve_histograms_2018/tnp_trackingplus_mc_vertexWeights1_oscharge0.root',
+                         '/scratch/rforti/steve_histograms_2018/tnp_trackingplus_data_vertexWeights1_oscharge0.root',
+                         '/scratch/rforti/steve_histograms_2018/tnp_trackingplus_bkg_vertexWeights1_oscharge0.root'],
+    'mu_tracking_minus': ['/scratch/rforti/steve_histograms_2018/tnp_trackingminus_mc_vertexWeights1_oscharge0.root',
+                          '/scratch/rforti/steve_histograms_2018/tnp_trackingminus_data_vertexWeights1_oscharge0.root',
+                          '/scratch/rforti/steve_histograms_2018/tnp_trackingminus_bkg_vertexWeights1_oscharge0.root'],
+    'mu_idip_plus': ['/scratch/rforti/steve_histograms_2018/tnp_idipplus_mc_vertexWeights1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2018/tnp_idipplus_data_vertexWeights1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2018/tnp_idipplus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_idip_minus': ['/scratch/rforti/steve_histograms_2018/tnp_idipminus_mc_vertexWeights1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2018/tnp_idipminus_data_vertexWeights1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2018/tnp_idipminus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_trigger_plus': ['/scratch/rforti/steve_histograms_2018/tnp_triggerplus_mc_vertexWeights1_oscharge1.root',
+                        '/scratch/rforti/steve_histograms_2018/tnp_triggerplus_data_vertexWeights1_oscharge1.root',
+                        '/scratch/rforti/steve_histograms_2018/tnp_triggerplus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_trigger_minus': ['/scratch/rforti/steve_histograms_2018/tnp_triggerminus_mc_vertexWeights1_oscharge1.root',
+                         '/scratch/rforti/steve_histograms_2018/tnp_triggerminus_data_vertexWeights1_oscharge1.root',
+                         '/scratch/rforti/steve_histograms_2018/tnp_triggerminus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_iso_both': ['/scratch/rforti/steve_histograms_2018/tnp_iso_mc_vertexWeights1_oscharge1.root',
+                    '/scratch/rforti/steve_histograms_2018/tnp_iso_data_vertexWeights1_oscharge1.root',
+                    '/scratch/rforti/steve_histograms_2018/tnp_iso_bkg_vertexWeights1_oscharge1.root'],
+}
+
+
 working_points_new = {
     'mu_reco_plus': ['/scratch/rforti/steve_histograms_2016/reco/tnp_recoplus_mc_vertexWeights1_genMatching1_oscharge1.root',
                      '/scratch/rforti/steve_histograms_2016/reco/tnp_recoplus_data_vertexWeights1_genMatching1_oscharge1.root',
@@ -86,7 +152,7 @@ bkg_types = ["WW", "WZ", "ZZ", "TTSemileptonic", "TTFullyleptonic", "Ztautau", "
              #"QCD", 
              "Zjets"]
 
-def lumi_factor(filepath, process):
+def lumi_factor(filepath, process, yr="2016"):
     """
     Returns the lumi factor for the process in the given file
     """
@@ -98,7 +164,7 @@ def lumi_factor(filepath, process):
     else:
         xsection = cross_sections_bkg[process]*1000
     lumi_process = num_init/xsection
-    scale = lumi_data/lumi_process
+    scale = lumi_data[yr]/lumi_process
     return scale
 
 
@@ -117,8 +183,11 @@ parser.add_argument('-s','--steps', default=None, nargs='*', type=str, choices=l
                     help='Default runs all working points, but can choose only some if needed')
 parser.add_argument('-x','--exclude', default=None, nargs='*', type=str, choices=list([x.split("_")[1] for x in working_points_global.keys()]),
                     help='Default runs all working points, but can exclude some if needed')
+parser.add_argument("-y", "--year", type=str, choices=["2016", "2017", "2018"], help="Year of data taking")
 parser.add_argument('--oldSteve', action='store_true',
                     help='Use input files from Steve that have the "old" naming scheme (i.e. with the "genMatching" flag)')
+parser.add_argument('--scale_bkg_by_lumi', action='store_true',
+                    help='Scale background datasets to match the luminosity of data')
                     
 args = parser.parse_args()
                     
@@ -127,32 +196,45 @@ if args.oldSteve is True:
     bkg_types.remove("Zjets") 
     bkg_types += ["mc"]
     datasets = working_points_new
+    args.scale_bkg_by_lumi = True
+elif args.year=="2017:
+    datasets = working_points_2017
+elif args.year=="2018":
+    datasets = working_points_2018
 else:
     datasets = working_points_global
-
+    
+ 
+if args.steps is None:
+    args.steps = list(set([k.split("_")[1] for k in working_points_global.keys()]))
+    
 for eff in args.steps:
-    for ch in ["plus", "minus"]:
+    for ch in ["plus", "minus", "both"]:
     
         if not f"mu_{eff}_{ch}" in datasets.keys(): 
             continue
         else:
             base_folder = datasets[f"mu_{eff}_{ch}"][0].replace(datasets[f"mu_{eff}_{ch}"][0].split("/")[-1], "")
             
-        os = 1 if eff!="tracking" else 0
+        os = 0 if eff=="tracking" else 1
         
-        print(bkg_types)
+        print(eff, ch, base_folder, os)
         
-        fnames = [base_folder+f"tnp_{eff}{ch}_{bkg_type}_vertexWeights1_genMatching0_oscharge{os}.root" for bkg_type in bkg_types]
+        ch_file = ch if ch!="both" else ""
+        
+        fnames = [base_folder+f"tnp_{eff}{ch_file}_{bkg_type}_vertexWeights1_genMatching0_oscharge{os}.root" for bkg_type in bkg_types]
         
         if args.oldSteve:
             fnames = [fname.replace("genMatching0", "genMatching-1") if "_mc_" in fname else fname for fname in fnames]
+            gm_info = "_genMatching0"
         else:
-            fnames = [fname.replace("_genMatching0_", "") for fname in fnames]
+            fnames = [fname.replace("_genMatching0", "") for fname in fnames]
+            gm_info = ""
 
         if len(datasets[f"mu_{eff}_{ch}"])==3:    
             file_out = ROOT.TFile(datasets[f"mu_{eff}_{ch}"][2], "RECREATE")
         else:
-            file_out = ROOT.TFile(f"{base_folder}tnp_{eff}{ch}_bkg_vertexWeights1_genMatching0_oscharge{os}.root", "RECREATE")
+            file_out = ROOT.TFile(f"{base_folder}tnp_{eff}{ch_file}_bkg_vertexWeights1{gm_info}_oscharge{os}.root", "RECREATE")
 
 
 
@@ -162,15 +244,20 @@ for eff in args.steps:
             rootfiles = []
             histos = []
 
-            for fname in fnames: rootfiles.append(ROOT.TFile(fname, "read"))
-
+            for fname in fnames: rootfiles.append(ROOT.TFile(fname, "READ"))       
+            
             for rf in rootfiles:
+            
                 histos.append(rf.Get(f"{fl}_mu_DY_postVFP"))
-                if args.oldSteve:
-                    bkg_process = rf.GetName().split("/")[-1].split("_")[2]
-                    if bkg_process == "mc": bkg_process = "Zjets"
-                histos[-1].Scale(lumi_factor(rf.GetName(), bkg_process))
-                print(f"Scaling {bkg_process} by {lumi_factor(rf.GetName(), bkg_process)}")
+                
+                bkg_process = rf.GetName().split("/")[-1].split("_")[2]
+                if args.oldSteve and bkg_process == "mc": bkg_process = "Zjets"
+                
+                if args.scale_bkg_by_lumi:
+                    scaling = lumi_factor(rf.GetName(), bkg_process, yr=args.year)
+                    print(f"Scaling {bkg_process} by {scaling}")
+                    histos[-1].Scale(scaling)
+                    
 
             hist_sum = histos[0].Clone(f"{fl}_mu_DY_postVFP")
             hist_sum.Reset()

--- a/create_totBkg_file.py
+++ b/create_totBkg_file.py
@@ -98,7 +98,10 @@ working_points_2017 = {
     'mu_iso_both': ['/scratch/rforti/steve_histograms_2017/tnp_iso_mc_vertexWeights1_oscharge1.root',
                     '/scratch/rforti/steve_histograms_2017/tnp_iso_data_vertexWeights1_oscharge1.root',
                     '/scratch/rforti/steve_histograms_2017/tnp_iso_bkg_vertexWeights1_oscharge1.root'],
-}
+    'mu_isonotrig_both': ['/scratch/rforti/steve_histograms_2017/tnp_isonotrig_mc_vertexWeights1_oscharge1.root',
+                          '/scratch/rforti/steve_histograms_2017/tnp_isonotrig_data_vertexWeights1_oscharge1.root',
+                          '/scratch/rforti/steve_histograms_2017/tnp_isonotrig_bkg_vertexWeights1_oscharge1.root'],
+    }
 
 
 working_points_2018 = {
@@ -130,8 +133,53 @@ working_points_2018 = {
     'mu_iso_both': ['/scratch/rforti/steve_histograms_2018/tnp_iso_mc_vertexWeights1_oscharge1.root',
                     '/scratch/rforti/steve_histograms_2018/tnp_iso_data_vertexWeights1_oscharge1.root',
                     '/scratch/rforti/steve_histograms_2018/tnp_iso_bkg_vertexWeights1_oscharge1.root'],
+    'mu_isonotrig_both': ['/scratch/rforti/steve_histograms_2018/tnp_isonotrig_mc_vertexWeights1_oscharge1.root',
+                          '/scratch/rforti/steve_histograms_2018/tnp_isonotrig_data_vertexWeights1_oscharge1.root',
+                          '/scratch/rforti/steve_histograms_2018/tnp_isonotrig_bkg_vertexWeights1_oscharge1.root'],
+    }
+
+
+working_points_2017_forVeto = {
+    'mu_reco_plus': ['/scratch/rforti/steve_histograms_2017/forVeto/tnp_recoplus_mc_vertexWeights1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2017/forVeto/tnp_recoplus_data_vertexWeights1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2017/forVeto/tnp_recoplus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_reco_minus': ['/scratch/rforti/steve_histograms_2017/forVeto/tnp_recominus_mc_vertexWeights1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2017/forVeto/tnp_recominus_data_vertexWeights1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2017/forVeto/tnp_recominus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_tracking_plus': ['/scratch/rforti/steve_histograms_2017/forVeto/tnp_trackingplus_mc_vertexWeights1_oscharge0.root',
+                     '/scratch/rforti/steve_histograms_2017/forVeto/tnp_trackingplus_data_vertexWeights1_oscharge0.root',
+                     '/scratch/rforti/steve_histograms_2017/forVeto/tnp_trackingplus_bkg_vertexWeights1_oscharge0.root'],
+    'mu_tracking_minus': ['/scratch/rforti/steve_histograms_2017/forVeto/tnp_trackingminus_mc_vertexWeights1_oscharge0.root',
+                      '/scratch/rforti/steve_histograms_2017/forVeto/tnp_trackingminus_data_vertexWeights1_oscharge0.root',
+                      '/scratch/rforti/steve_histograms_2017/forVeto/tnp_trackingminus_bkg_vertexWeights1_oscharge0.root'],
+    'mu_veto_plus': ['/scratch/rforti/steve_histograms_2017/forVeto/tnp_vetoplus_mc_vertexWeights1_oscharge1.root',
+                    '/scratch/rforti/steve_histograms_2017/forVeto/tnp_vetoplus_data_vertexWeights1_oscharge1.root',
+                    '/scratch/rforti/steve_histograms_2017/forVeto/tnp_vetoplus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_veto_minus': ['/scratch/rforti/steve_histograms_2017/forVeto/tnp_vetominus_mc_vertexWeights1_oscharge1.root',
+                    '/scratch/rforti/steve_histograms_2017/forVeto/tnp_vetominus_data_vertexWeights1_oscharge1.root',
+                    '/scratch/rforti/steve_histograms_2017/forVeto/tnp_vetominus_bkg_vertexWeights1_oscharge1.root']
 }
 
+working_points_2018_forVeto = {
+    'mu_reco_plus': ['/scratch/rforti/steve_histograms_2018/forVeto/tnp_recoplus_mc_vertexWeights1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2018/forVeto/tnp_recoplus_data_vertexWeights1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2018/forVeto/tnp_recoplus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_reco_minus': ['/scratch/rforti/steve_histograms_2018/forVeto/tnp_recominus_mc_vertexWeights1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2018/forVeto/tnp_recominus_data_vertexWeights1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2018/forVeto/tnp_recominus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_tracking_plus': ['/scratch/rforti/steve_histograms_2018/forVeto/tnp_trackingplus_mc_vertexWeights1_oscharge0.root',
+                     '/scratch/rforti/steve_histograms_2018/forVeto/tnp_trackingplus_data_vertexWeights1_oscharge0.root',
+                     '/scratch/rforti/steve_histograms_2018/forVeto/tnp_trackingplus_bkg_vertexWeights1_oscharge0.root'],
+    'mu_tracking_minus': ['/scratch/rforti/steve_histograms_2018/forVeto/tnp_trackingminus_mc_vertexWeights1_oscharge0.root',
+                      '/scratch/rforti/steve_histograms_2018/forVeto/tnp_trackingminus_data_vertexWeights1_oscharge0.root',
+                      '/scratch/rforti/steve_histograms_2018/forVeto/tnp_trackingminus_bkg_vertexWeights1_oscharge0.root'],
+    'mu_veto_plus': ['/scratch/rforti/steve_histograms_2018/forVeto/tnp_vetoplus_mc_vertexWeights1_oscharge1.root',
+                    '/scratch/rforti/steve_histograms_2018/forVeto/tnp_vetoplus_data_vertexWeights1_oscharge1.root',
+                    '/scratch/rforti/steve_histograms_2018/forVeto/tnp_vetoplus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_veto_minus': ['/scratch/rforti/steve_histograms_2018/forVeto/tnp_vetominus_mc_vertexWeights1_oscharge1.root',
+                    '/scratch/rforti/steve_histograms_2018/forVeto/tnp_vetominus_data_vertexWeights1_oscharge1.root',
+                    '/scratch/rforti/steve_histograms_2018/forVeto/tnp_vetominus_bkg_vertexWeights1_oscharge1.root']
+}
 
 working_points_new = {
     'mu_reco_plus': ['/scratch/rforti/steve_histograms_2016/reco/tnp_recoplus_mc_vertexWeights1_genMatching1_oscharge1.root',
@@ -184,6 +232,7 @@ parser.add_argument('-s','--steps', default=None, nargs='*', type=str, choices=l
 parser.add_argument('-x','--exclude', default=None, nargs='*', type=str, choices=list([x.split("_")[1] for x in working_points_global.keys()]),
                     help='Default runs all working points, but can exclude some if needed')
 parser.add_argument("-y", "--year", type=str, choices=["2016", "2017", "2018"], help="Year of data taking")
+parser.add_argument('--forVeto', action='store_true', help='Use the working points related to veto')               
 parser.add_argument('--oldSteve', action='store_true',
                     help='Use input files from Steve that have the "old" naming scheme (i.e. with the "genMatching" flag)')
 parser.add_argument('--scale_bkg_by_lumi', action='store_true',
@@ -197,10 +246,10 @@ if args.oldSteve is True:
     bkg_types += ["mc"]
     datasets = working_points_new
     args.scale_bkg_by_lumi = True
-elif args.year=="2017":
-    datasets = working_points_2017
-elif args.year=="2018":
-    datasets = working_points_2018
+elif args.year=="2017" :
+    datasets = working_points_2017 if not args.forVeto else working_points_2017_forVeto
+elif args.year=="2018" :
+    datasets = working_points_2018 if not args.forVeto else working_points_2018_forVeto
 else:
     datasets = working_points_global
     

--- a/libCpp/RooCMSShape.cc
+++ b/libCpp/RooCMSShape.cc
@@ -10,49 +10,49 @@
  *   Kalanand Mishra, Fermilab - kalanand@fnal.gov
  *
  * Description:
- *   Defines a probability density function which has exponential decay 
- *   distribution at high mass beyond the pole position (say, Z peak)  
- *   but turns over (i.e., error function) at low mass due to threshold 
- *   effect. We use this to model the background shape in Z->ll invariant 
+ *   Defines a probability density function which has exponential decay
+ *   distribution at high mass beyond the pole position (say, Z peak)
+ *   but turns over (i.e., error function) at low mass due to threshold
+ *   effect. We use this to model the background shape in Z->ll invariant
  *   mass.
  * History:
- *   
+ *
  *
  *****************************************************************************/
 
 #include "RooCMSShape.h"
 
-ClassImp(RooCMSShape) 
+ClassImp(RooCMSShape)
 
- RooCMSShape::RooCMSShape(const char *name, const char *title, 
+ RooCMSShape::RooCMSShape(const char *name, const char *title,
                         RooAbsReal& _x,
                         RooAbsReal& _alpha,
                         RooAbsReal& _beta,
                         RooAbsReal& _gamma,
                         RooAbsReal& _peak) :
-   RooAbsPdf(name,title), 
+   RooAbsPdf(name,title),
    x("x","x",this,_x),
    alpha("alpha","alpha",this,_alpha),
    beta("beta","beta",this,_beta),
    gamma("gamma","gamma",this,_gamma),
    peak("peak","peak",this,_peak)
- { } 
+ { }
 
 
  RooCMSShape::RooCMSShape(const RooCMSShape& other, const char* name):
-   RooAbsPdf(other,name), 
+   RooAbsPdf(other,name),
    x("x",this,other.x),
    alpha("alpha",this,other.alpha),
    beta("beta",this,other.beta),
    gamma("gamma",this,other.gamma),
    peak("peak",this,other.peak)
- { } 
+ { }
 
 
 
- Double_t RooCMSShape::evaluate() const 
- { 
-  // ENTER EXPRESSION IN TERMS OF VARIABLE ARGUMENTS HERE 
+ Double_t RooCMSShape::evaluate() const
+ {
+  // ENTER EXPRESSION IN TERMS OF VARIABLE ARGUMENTS HERE
 
   //Double_t erf = TMath::Erfc((alpha - x) * beta);
   // Double_t erf = RooMath::erfc((alpha - x) * beta);
@@ -63,4 +63,46 @@ ClassImp(RooCMSShape)
   else if( u>70 ) u = 0;
   else u = exp(-u);   //exponential decay
   return erf*u;
- } 
+ }
+
+
+ Int_t RooCMSShape::getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName) const
+ {
+   if (matchArgs(allVars,analVars,x)) return 1 ;
+   return 0 ;
+ }
+
+ double RooCMSShape::analyticalIntegral(Int_t code, const char* rangeName) const
+ {
+   switch(code) {
+     case 1:
+     {
+
+       Double_t max = x.max(rangeName);
+       Double_t min = x.min(rangeName);
+
+       Double_t inner = (-alpha/beta) + 0.5*beta*gamma;
+
+       Double_t term0 = 1.0/gamma;
+
+       Double_t term1 = exp( 0.25*gamma*( (-4.0*alpha) + (beta*beta*gamma) + (4.0*peak) ) );
+
+       Double_t term2 = exp(gamma*(peak-min)) * RooMath::erfc((alpha-min)/beta);
+
+       Double_t term3 = exp(gamma*(peak-max)) * RooMath::erfc((alpha-max)/beta);
+
+       Double_t add1 = RooMath::erf(inner + (max/beta));
+
+       Double_t add2 = RooMath::erf(inner + (min/beta));
+
+       Double_t integral = term0 * ( (term1*(add1-add2)) + term2 - term3 );
+
+       //std::cout << integral << std::endl;
+
+       return integral ;
+     }
+   }
+   assert(0) ;
+   return 0 ;
+ }
+

--- a/libCpp/RooCMSShape.h
+++ b/libCpp/RooCMSShape.h
@@ -10,13 +10,13 @@
  *   Kalanand Mishra, Fermilab - kalanand@fnal.gov
  *
  * Description:
- *   Defines a probability density function which has exponential decay 
- *   distribution at high mass beyond the pole position (say, Z peak)  
- *   but turns over (i.e., error function) at low mass due to threshold 
- *   effect. We use this to model the background shape in Z->ll invariant 
+ *   Defines a probability density function which has exponential decay
+ *   distribution at high mass beyond the pole position (say, Z peak)
+ *   but turns over (i.e., error function) at low mass due to threshold
+ *   effect. We use this to model the background shape in Z->ll invariant
  *   mass.
  * History:
- *   
+ *
  *
  *****************************************************************************/
 
@@ -43,6 +43,12 @@ public:
   inline virtual TObject* clone(const char* newname) const { return new RooCMSShape(*this,newname); }
   inline ~RooCMSShape() {}
   Double_t evaluate() const ;
+
+  
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars,
+                              const char* rangeName=nullptr) const ;
+
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const ;
   
 
   ClassDef(RooCMSShape,2);
@@ -54,7 +60,7 @@ protected:
   RooRealProxy beta ;
   RooRealProxy gamma ;
   RooRealProxy peak ;
-  
+
 };
- 
+
 #endif

--- a/libCpp/histFitter.C
+++ b/libCpp/histFitter.C
@@ -44,6 +44,7 @@ public:
   tnpFitter( TH1 *hPass, TH1 *hFail, std::string histname, int massbins, float massmin, float massmax  );
     ~tnpFitter(); //{ if( _work != 0 ) delete _work; }
   void setZLineShapes(TH1 *hZPass, TH1 *hZFail );
+  void setTotalBkgShapes(TH1 *hBkgPass, TH1 *hBkgFail );
   void setWorkspace(const std::vector<std::string>&, bool, bool, bool);
   //void setOutputFile(const std::string& fname ) {_fOut = new TFile(fname.c_str(), "recreate"); } 
   void setOutputFile(const std::string& fname );
@@ -219,6 +220,13 @@ void tnpFitter::setConstantVariable(const std::string& name, const double& val =
 void tnpFitter::setZLineShapes(TH1 *hZPass, TH1 *hZFail ) {
   RooDataHist rooPass("hGenZPass","hGenZPass",*_work->var("x"),hZPass);
   RooDataHist rooFail("hGenZFail","hGenZFail",*_work->var("x"),hZFail);
+  _work->import(rooPass) ;
+  _work->import(rooFail) ;  
+}
+
+void tnpFitter::setTotalBkgShapes(TH1 *hBkgPass, TH1 *hBkgFail ) {
+  RooDataHist rooPass("hTotBkgPass","hTotBkgPass",*_work->var("x"),hBkgPass);
+  RooDataHist rooFail("hTotBkgFail","hTotBkgFail",*_work->var("x"),hBkgFail);
   _work->import(rooPass) ;
   _work->import(rooFail) ;  
 }

--- a/libPython/EGammaID_scaleFactors.py
+++ b/libPython/EGammaID_scaleFactors.py
@@ -321,15 +321,13 @@ def doSFs(filein, lumi, axis = ['pT','eta'], plotdir='' ):
             etaKey = ( float(numbers[0]), float(numbers[1]) )
             ptKey  = ( float(numbers[2]), min(500,float(numbers[3])) )
         
-            myeff = efficiency( ptKey,etaKey,
-                                float(numbers[4]),float(numbers[5]), ## data eff and error
-                                float(numbers[6]),float(numbers[7]), ## mc eff and error
-                                float(numbers[12]), ## eff data alt bkg model
-                                float(numbers[8] ), float(numbers[9]), ## eff data alt sig model and error 
-                                float(numbers[10]),float(numbers[11]), ## eff mc alt sig model and error 
-                                float(numbers[13]) )
-#                           float(numbers[8]),float(numbers[9]),float(numbers[10]), -1 )
-
+            myeff = efficiency( ptKey, etaKey,
+                                float(numbers[4]), float(numbers[5]), ## data eff and error
+                                float(numbers[6]), float(numbers[7]), ## mc eff and error
+                                float(numbers[8]), float(numbers[9]),    ## data_alt_sig eff and error
+                                float(numbers[10]), float(numbers[11]),  ## data_alt_bkg eff and error
+                                float(numbers[12]), float(numbers[13]),  ## eff_alt_sig eff and error
+                                float(numbers[14]) )
             effGraph.addEfficiency(myeff)
 
     fileWithEff.close()
@@ -366,7 +364,7 @@ def doSFs(filein, lumi, axis = ['pT','eta'], plotdir='' ):
 #EffiGraph1D( effGraph.pt_1DGraph_list_customEtaBining(customEtaBining,False) , 
 #             effGraph.pt_1DGraph_list_customEtaBining(customEtaBining,True)   , False, pdfout )
 #    EffiGraph1D( effGraph.eta_1DGraph_list(False), effGraph.eta_1DGraph_list(True), True , pdfout )
-    listOfSF1D .extend( EffiGraph1D( effGraph.eta_1DGraph_list( typeGR =  0 ) , # eff Data
+    listOfSF1D.extend( EffiGraph1D( effGraph.eta_1DGraph_list( typeGR =  0 ) , # eff Data
                               effGraph.eta_1DGraph_list( typeGR = -1 ) , # eff MC
                               effGraph.eta_1DGraph_list( typeGR = +1 ) , # SF
                               pdfout, 
@@ -375,11 +373,13 @@ def doSFs(filein, lumi, axis = ['pT','eta'], plotdir='' ):
     h2EffData       = effGraph.ptEtaScaleFactor_2DHisto(40)
     h2EffMC         = effGraph.ptEtaScaleFactor_2DHisto(41)
     h2EffDataAltSig = effGraph.ptEtaScaleFactor_2DHisto(42)
-    h2EffMCAltSig   = effGraph.ptEtaScaleFactor_2DHisto(43)
+    h2EffDataAltBkg   = effGraph.ptEtaScaleFactor_2DHisto(43)
+    h2EffMCAltSig   = effGraph.ptEtaScaleFactor_2DHisto(44)
     h2StatUncEffData       = effGraph.ptEtaScaleFactor_2DHisto(50)
     h2StatUncEffMC         = effGraph.ptEtaScaleFactor_2DHisto(51)
     h2StatUncEffDataAltSig = effGraph.ptEtaScaleFactor_2DHisto(52)
-    h2StatUncEffMCAltSig   = effGraph.ptEtaScaleFactor_2DHisto(53)
+    h2StatUncEffDataAltBkg   = effGraph.ptEtaScaleFactor_2DHisto(53)
+    h2StatUncEffMCAltSig   = effGraph.ptEtaScaleFactor_2DHisto(54)
     #h2SF      = effGraph.ptEtaScaleFactor_2DHisto(-1)
     h2SF = h2EffData.Clone('h2_SF_nominal');
     h2SF.SetTitle('SF nominal data / nominal MC')
@@ -387,6 +387,9 @@ def doSFs(filein, lumi, axis = ['pT','eta'], plotdir='' ):
     h2SFDataAltSig = h2EffDataAltSig.Clone('h2_SF_dataAltSig');
     h2SFDataAltSig.SetTitle('SF altSig data / nominal MC')
     h2SFDataAltSig.Divide(h2EffMC)
+    h2SFDataAltBkg = h2EffDataAltBkg.Clone('h2_SF_dataAltBkg');
+    h2SFDataAltBkg.SetTitle('SF altBkg data / nominal MC')
+    h2SFDataAltBkg.Divide(h2EffMC)
     h2SFMCAltSig = h2EffData.Clone('h2_SF_MCAltSig');
     h2SFMCAltSig.SetTitle('SF nominal data / altSig MC')
     h2SFMCAltSig.Divide(h2EffMCAltSig)
@@ -436,6 +439,7 @@ def doSFs(filein, lumi, axis = ['pT','eta'], plotdir='' ):
     h2EffDataAltSig.Write('EffDataAltSig2D', rt.TObject.kOverwrite)
     h2EffMCAltSig  .Write('EffMCAltSig2D'  , rt.TObject.kOverwrite)
     h2SFDataAltSig.Write('SF2D_dataAltSig', rt.TObject.kOverwrite)
+    h2SFDataAltBkg.Write('SF2D_dataAltBkg', rt.TObject.kOverwrite)
     h2SFMCAltSig.Write('SF2D_MCAltSig', rt.TObject.kOverwrite)
     h2SFDataMCAltSig.Write('SF2D_dataMCAltSig', rt.TObject.kOverwrite)
     for igr in listOfSF1D:
@@ -447,7 +451,7 @@ def doSFs(filein, lumi, axis = ['pT','eta'], plotdir='' ):
 
     cDummy.Print( pdfout + "]" )
 
-    allEffsAndSFs= [h2SF, h2EffData, h2EffMC, h2EffDataAltSig, h2EffMCAltSig, h2SFDataAltSig, h2SFMCAltSig, h2SFDataMCAltSig, h2StatUncEffData, h2StatUncEffMC, h2StatUncEffDataAltSig, h2StatUncEffMCAltSig]
+    allEffsAndSFs= [h2SF, h2EffData, h2EffMC, h2EffDataAltSig, h2EffDataAltBkg, h2EffMCAltSig, h2SFDataAltSig, h2SFDataAltBkg, h2SFMCAltSig, h2SFDataMCAltSig, h2StatUncEffData, h2StatUncEffMC, h2StatUncEffDataAltSig, h2StatUncEffDataAltBkg, h2StatUncEffMCAltSig]
     canv = rt.TCanvas('c','c', 800, 800)
     canv.SetRightMargin(0.20)
     rt.gStyle.SetPalette(55)

--- a/libPython/efficiencyUtils.py
+++ b/libPython/efficiencyUtils.py
@@ -19,7 +19,7 @@ class efficiency:
         self.altEff  = [-1]*7
         self.syst    = [-1]*7
     
-    def __init__(self,ptBin,etaBin,effData,errEffData,effMC,errEffMC,effAltBkgModel,effAltSigModel,errAltSigModel,effAltMCSignal,errAltMCSig,effAltTagSel):
+    def __init__(self,ptBin,etaBin,effData,errEffData,effMC,errEffMC,effAltSigModel,errAltSigModel,effAltBkgModel,errAltBkgModel,effAltMCSignal,errAltMCSig,effAltTagSel):
         self.ptBin      = ptBin
         self.etaBin     = etaBin
         self.effData    = effData
@@ -28,6 +28,8 @@ class efficiency:
         self.errEffMC   = errEffMC
         self.effAltSig = effAltSigModel
         self.errAltSig = errAltSigModel
+        self.effAltBkg = effAltBkgModel
+        self.errAltBkg = errAltBkgModel
         self.effAltSigMC = effAltMCSignal
         self.errAltSigMC = errAltMCSig
         self.altEff = [-1]*7
@@ -40,12 +42,13 @@ class efficiency:
     def __str__(self):
         return '%2.3f\t%2.3f\t%2.1f\t%2.1f\t%2.4f\t%2.4f\t%2.4f\t%2.4f\t%2.4f\t%2.4f\t%2.4f\t%2.4f' % (self.etaBin[0],self.etaBin[1],
                                                                                                        self.ptBin[0] ,self.ptBin[1] ,
-                                                                                                       self.effData, self.errEffData, self.effMC, self.errEffMC,
-                                                                                                       self.altEff[0],self.altEff[1], self.altEff[2], self.altEff[3] )
+                                                                                                       self.effData, self.errEffData, 
+                                                                                                       self.effMC, self.errEffMC,
+                                                                                                       self.altEff[0],self.altEff[1],self.altEff[2],self.altEff[3])
 
     @staticmethod
     def getSystematicNames():
-        return [ 'statData', 'statMC', 'altBkgModel', 'altSignalModel', 'altMCEff', 'altTagSelection' ]
+        return [ 'statData', 'statMC', 'altSignalModel', 'altBkgModel', 'altMCEff', 'altTagSelection']
 
 
 
@@ -269,6 +272,9 @@ class efficiencyList:
             htitle = 'lepton efficiencies data altSig'
             hname  = 'h2_effDataAltSig'
         if onlyError   == 43 :
+            htitle = 'lepton efficiencies data altBkg'
+            hname  = 'h2_effDataAltBkg'
+        if onlyError   == 44 :
             htitle = 'lepton efficiencies MC altSig'
             hname  = 'h2_effMCAltSig'             
         if onlyError   == 50 :
@@ -281,6 +287,9 @@ class efficiencyList:
             htitle = 'lepton eff. stat. unc. data altSig'
             hname  = 'h2_statUncEffDataAltSig'
         if onlyError   == 53 :
+            htitle = 'lepton eff. stat. unc. data altBkg'
+            hname  = 'h2_statUncEffDataAltBkg'
+        if onlyError   == 54 :
             htitle = 'lepton eff. stat. unc. MC altSig'
             hname  = 'h2_statUncEffMCAltSig'             
 
@@ -351,6 +360,9 @@ class efficiencyList:
                             h2.SetBinContent(ix,iy, self.effList[ptBin][etaBin].effAltSig)
                             h2.SetBinError  (ix,iy, self.effList[ptBin][etaBin].errAltSig)
                         if onlyError   == 43 :
+                            h2.SetBinContent(ix,iy, self.effList[ptBin][etaBin].effAltBkg)
+                            h2.SetBinError  (ix,iy, self.effList[ptBin][etaBin].errAltBkg)
+                        if onlyError   == 44 :
                             h2.SetBinContent(ix,iy, self.effList[ptBin][etaBin].effAltSigMC)
                             h2.SetBinError  (ix,iy, self.effList[ptBin][etaBin].errAltSigMC)
                         if onlyError   == 50 :
@@ -360,6 +372,8 @@ class efficiencyList:
                         if onlyError   == 52 :
                             h2.SetBinContent  (ix,iy, self.effList[ptBin][etaBin].errAltSig)
                         if onlyError   == 53 :
+                            h2.SetBinContent  (ix,iy, self.effList[ptBin][etaBin].errAltBkg)
+                        if onlyError   == 54 :
                             h2.SetBinContent  (ix,iy, self.effList[ptBin][etaBin].errAltSigMC)
 
         h2.GetXaxis().SetTitle("#eta")

--- a/libPython/fitUtils.py
+++ b/libPython/fitUtils.py
@@ -312,25 +312,17 @@ def histFitterAltBkg( sample, tnpBin, tnpWorkspaceParam, massbins=60, massmin=60
 
     analyticPhysicsShape = False
 
-    '''
     defaultBkgShapes = [
         "Exponential::bkgPass(x, expalphaP)",
         "Exponential::bkgFail(x, expalphaF)",
     ]
-    '''
 
-    defaultBkgShapes = [
-        "RooHistPdf::bkgPass(x, hTotBkgPass, 0)",
-        "RooHistPdf::bkgFail(x, hTotBkgFail, 0)",
-    ]
-        
     tnpWorkspaceFunc = [
         "Gaussian::sigResPass(x,meanP,sigmaP)",
         "Gaussian::sigResFail(x,meanF,sigmaF)",
-    ]
+        ]
 
-    tnpWorkspaceFunc.extend(defaultBkgShapes)
-
+    tnpWorkspaceFunc.extend(bkgShapes if len(bkgShapes) else defaultBkgShapes)
 
     tnpWorkspace = []
     tnpWorkspace.extend(tnpWorkspaceParam)
@@ -375,15 +367,6 @@ def histFitterAltBkg( sample, tnpBin, tnpWorkspaceParam, massbins=60, massmin=60
 
     fitter.setZLineShapes(histZLineShapeP,histZLineShapeF)
     fileTruth.Close()
-
-
-    #background template histogram
-    fileTotalBkg = ROOT.TFile(sample.bkgRef.getOutputPath(),'read')
-    histTotalBkgP = fileTotalBkg.Get('%s_Pass'%tnpBin['name'])
-    histTotalBkgF = fileTotalBkg.Get('%s_Fail'%tnpBin['name'])
-
-    fitter.setTotalBkgShapes(histTotalBkgP,histTotalBkgF)
-    fileTotalBkg.Close()
 
     if len(constrainPars):
         tnpWorkspace.extend(constrainPars)
@@ -415,13 +398,18 @@ def histFitterAltBkg( sample, tnpBin, tnpWorkspaceParam, massbins=60, massmin=60
 def histFitterAltBkgTemplate(sample, tnpBin, tnpWorkspaceParam, massbins=60, massmin=60, massmax=120, useAllTemplateForFail=False, maxFailIntegralToUseAllProbe=-1, constrainPars=[]):
 
     analyticPhysicsShape = False
+
+    defaultBkgShapes = [
+        "RooHistPdf::bkgPass(x, hTotBkgPass, 0)",
+        "RooHistPdf::bkgFail(x, hTotBkgFail, 0)",
+    ]
         
     tnpWorkspaceFunc = [
         "Gaussian::sigResPass(x,meanP,sigmaP)",
         "Gaussian::sigResFail(x,meanF,sigmaF)",
         ]
-
-
+    
+    tnpWorkspaceFunc.extend(defaultBkgShapes)
 
     tnpWorkspace = []
     tnpWorkspace.extend(tnpWorkspaceParam)
@@ -466,6 +454,14 @@ def histFitterAltBkgTemplate(sample, tnpBin, tnpWorkspaceParam, massbins=60, mas
 
     fitter.setZLineShapes(histZLineShapeP,histZLineShapeF)
     fileTruth.Close()
+
+    #background template histogram
+    fileTotalBkg = ROOT.TFile(sample.bkgRef.getOutputPath(),'read')
+    histTotalBkgP = fileTotalBkg.Get('%s_Pass'%tnpBin['name'])
+    histTotalBkgF = fileTotalBkg.Get('%s_Fail'%tnpBin['name'])
+
+    fitter.setTotalBkgShapes(histTotalBkgP,histTotalBkgF)
+    fileTotalBkg.Close()
 
     if len(constrainPars):
         tnpWorkspace.extend(constrainPars)

--- a/libPython/rootUtils.py
+++ b/libPython/rootUtils.py
@@ -112,7 +112,8 @@ def getAllEffi(info, bindef, outputDirectory, saveCanvas=False):
     effis = {}
     effis_canvas = {}
     binName = bindef["name"]
-    canvasesToGet = ["dataNominal", "dataAltSig", "mcAltSig"]
+    #canvasesToGet = ["dataNominal", "dataAltSig", "dataAltBkg", "mcAltSig"]
+    canvasesToGet = ["dataNominal", "dataAltSig", "dataAltBkg"]
     for key in info.keys():
         value = info[key]
         if value is None or not os.path.isfile(value):
@@ -195,6 +196,77 @@ def getAllEffi(info, bindef, outputDirectory, saveCanvas=False):
     txt.DrawLatex(0.01, 0.97, '{n}'.format(n=bindef['name'].replace('_',' ').replace('To', '-').replace('probe ', '').replace('m','-').replace('pt','XX').replace('p','.').replace('XX','p_{T}')))
     txt.SetTextSize(0.08)
     ipad = 1
+    for ip, p in enumerate(effis_canvas["canv_dataNominal"].GetListOfPrimitives()):  # Draw the data_nominal, with info on the MC counting efficiency
+        if not ip: continue
+        canv_all.cd(ipad)
+        newp = p.Clone(f"tmp_dataNominal_{ip}")
+        newp.SetPad(0.05, 0.00, 0.95, 0.90)
+        newp.Draw()
+        ipad += 1
+    canv_all.cd(ipad)
+    tmp = effis['dataNominal']
+    txt.SetTextFont(62)
+    txt.DrawLatex(0.00, 0.85, 'data nominal:')
+    txt.SetTextFont(42)
+    txt.DrawLatex(0.10, 0.75, 'passing: {n:.1f} #pm {ne:.1f}'.format(n=tmp[2],ne=tmp[4]))
+    txt.DrawLatex(0.10, 0.64, 'failing: {n:.1f} #pm {ne:.1f}'.format(n=tmp[3],ne=tmp[5]))
+    txt.SetTextFont(62)
+    txt.DrawLatex(0.10, 0.53, 'efficiency: {e:.2f} #pm {ee:.2f} %'.format(e=tmp[0]*100., ee=tmp[1]*100.))
+    txt.SetTextFont(42)
+    tmp = effis['mcNominal']
+    txt.SetTextFont(62)
+    txt.DrawLatex(0.00, 0.35, 'MC counting efficiency:')
+    txt.SetTextFont(42)
+    txt.DrawLatex(0.10, 0.24, 'passing: {n:.1f} #pm {ne:.1f}'.format(n=tmp[2],ne=tmp[4]))
+    txt.DrawLatex(0.10, 0.13, 'failing: {n:.1f} #pm {ne:.1f}'.format(n=tmp[3],ne=tmp[5]))
+    txt.SetTextFont(62)
+    txt.DrawLatex(0.10, 0.02, 'efficiency: {e:.2f} #pm {ee:.2f} %'.format(e=tmp[0]*100., ee=tmp[1]*100.))
+    txt.SetTextFont(42) 
+    ipad += 1
+    for ip, p in enumerate(effis_canvas["canv_dataAltSig"].GetListOfPrimitives()):   # Draw the data_alt_signal
+        if not ip: continue
+        canv_all.cd(ipad)
+        newp = p.Clone(f"tmp_dataAltSig_{ip}")
+        newp.SetPad(0.05, 0.00, 0.95, 0.90)
+        newp.Draw()
+        ipad+=1
+    canv_all.cd(ipad)
+    tmp = effis['dataAltSig']
+    txt.SetTextFont(62)
+    txt.DrawLatex(0.00, 0.65, 'data alt. signal:')
+    txt.SetTextFont(42)
+    txt.DrawLatex(0.10, 0.54, 'passing: {n:.1f} #pm {ne:.1f}'.format(n=tmp[2],ne=tmp[4]))
+    txt.DrawLatex(0.10, 0.43, 'failing: {n:.1f} #pm {ne:.1f}'.format(n=tmp[3],ne=tmp[5]))
+    txt.SetTextFont(62)
+    txt.DrawLatex(0.10, 0.32, 'efficiency: {e:.2f} #pm {ee:.2f} %'.format(e=tmp[0]*100., ee=tmp[1]*100.))
+    txt.SetTextFont(42)
+    ipad+=1
+    for ip, p in enumerate(effis_canvas["canv_dataAltBkg"].GetListOfPrimitives()):   # Draw the data_alt_background
+        if not ip: continue
+        canv_all.cd(ipad)
+        newp = p.Clone(f"tmp_dataAltBkg_{ip}")
+        newp.SetPad(0.05, 0.00, 0.95, 0.90)
+        newp.Draw()
+        ipad += 1
+    canv_all.cd(ipad)
+    tmp = effis['dataAltBkg']
+    txt.SetTextFont(62)
+    txt.DrawLatex(0.00, 0.65, 'data alt. background:')
+    txt.SetTextFont(42)
+    txt.DrawLatex(0.10, 0.54, 'passing: {n:.1f} #pm {ne:.1f}'.format(n=tmp[2],ne=tmp[4]))
+    txt.DrawLatex(0.10, 0.43, 'failing: {n:.1f} #pm {ne:.1f}'.format(n=tmp[3],ne=tmp[5]))
+    txt.SetTextFont(62)
+    txt.DrawLatex(0.10, 0.32, 'efficiency: {e:.2f} #pm {ee:.2f} %'.format(e=tmp[0]*100., ee=tmp[1]*100.))
+    txt.SetTextFont(42)
+    canv_all.SaveAs(outputDirectory+'/plots/{n}_all.pdf'.format(n=bindef['name']))
+    canv_all.SaveAs(outputDirectory+'/plots/{n}_all.png'.format(n=bindef['name']))
+    
+    '''
+    ## ----------------------------------------------------------------------------
+    ## OLD VERSION: the first canvases are of the fit on MC, that is no longer used
+    ## ----------------------------------------------------------------------------          
+
+    ipad = 1
     # for ip, p in enumerate(padsFromCanvas["canv_mcAltSig"]):
     for ip, p in enumerate(effis_canvas["canv_mcAltSig"].GetListOfPrimitives()):
         if not ip: continue
@@ -262,6 +334,7 @@ def getAllEffi(info, bindef, outputDirectory, saveCanvas=False):
     txt.SetTextFont(42)
     canv_all.SaveAs(outputDirectory+'/plots/{n}_all.pdf'.format(n=bindef['name']))
     canv_all.SaveAs(outputDirectory+'/plots/{n}_all.png'.format(n=bindef['name']))
+    '''
     # not sure if the following helps removing crashes
     #canv_all = None
     #canv_all.Clear()

--- a/runFits.py
+++ b/runFits.py
@@ -24,10 +24,10 @@ def runCommands(wp, era, inputMC, inputData, options, inputBkg=None):
     ex = 'tnpEGM_fitter.py'
     cmds.append(['python', ex, opt_e, opt_f, '--createBins'                   ])
     cmds.append(['python', ex, opt_e, opt_f, opt_iMC , opt_iData, opt_iBkg, '--createHists'])
-    cmds.append(['python', ex, opt_e, opt_f, '--doFit',                        ])
-    cmds.append(['python', ex, opt_e, opt_f, '--doFit', '--mcSig'                        ])
-    cmds.append(['python', ex, opt_e, opt_f, '--doFit', '--mcSig',  '--altSig'])
-    cmds.append(['python', ex, opt_e, opt_f, '--doFit',             '--altSig'])
+    #cmds.append(['python', ex, opt_e, opt_f, '--doFit',                        ])
+    #cmds.append(['python', ex, opt_e, opt_f, '--doFit', '--mcSig'                        ])
+    #cmds.append(['python', ex, opt_e, opt_f, '--doFit', '--mcSig',  '--altSig'])
+    #cmds.append(['python', ex, opt_e, opt_f, '--doFit',             '--altSig'])
     #cmds.append(['python', ex, opt_e, opt_f, '--doFit', '--mcSig',  '--altBkg'])
     cmds.append(['python', ex, opt_e, opt_f, '--doFit',             '--altBkg'])
     cmds.append(['python', ex, opt_e, opt_f, '--sumUp'                        ])
@@ -93,6 +93,9 @@ working_points_new = {
     'mu_reco_plus': ['/scratch/rforti/steve_histograms_2016/reco/tnp_recoplus_mc_vertexWeights1_genMatching1_oscharge1.root',
                      '/scratch/rforti/steve_histograms_2016/reco/tnp_recoplus_data_vertexWeights1_genMatching1_oscharge1.root',
                      '/scratch/rforti/steve_histograms_2016/reco/tnp_recoplus_bkg_vertexWeights1_genMatching0_oscharge1.root'],
+    'mu_tracking_plus': ['/scratch/rforti/steve_histograms_2016/tracking/tnp_trackingplus_mc_vertexWeights1_genMatching1_oscharge0.root',
+                         '/scratch/rforti/steve_histograms_2016/tracking/tnp_trackingplus_data_vertexWeights1_genMatching1_oscharge0.root',
+                          '/scratch/rforti/steve_histograms_2016/tracking/tnp_trackingplus_bkg_vertexWeights1_genMatching0_oscharge0.root'],
 }
 
 

--- a/runFits.py
+++ b/runFits.py
@@ -24,10 +24,10 @@ def runCommands(wp, era, inputMC, inputData, options, inputBkg=None):
     ex = 'tnpEGM_fitter.py'
     cmds.append(['python', ex, opt_e, opt_f, '--createBins'                   ])
     cmds.append(['python', ex, opt_e, opt_f, opt_iMC , opt_iData, opt_iBkg, '--createHists'])
-    #cmds.append(['python', ex, opt_e, opt_f, '--doFit',                        ])
-    #cmds.append(['python', ex, opt_e, opt_f, '--doFit', '--mcSig'                        ])
-    #cmds.append(['python', ex, opt_e, opt_f, '--doFit', '--mcSig',  '--altSig'])
-    #cmds.append(['python', ex, opt_e, opt_f, '--doFit',             '--altSig'])
+    cmds.append(['python', ex, opt_e, opt_f, '--doFit',                        ])
+    cmds.append(['python', ex, opt_e, opt_f, '--doFit', '--mcSig'                        ])
+    cmds.append(['python', ex, opt_e, opt_f, '--doFit', '--mcSig',  '--altSig'])
+    cmds.append(['python', ex, opt_e, opt_f, '--doFit',             '--altSig'])
     #cmds.append(['python', ex, opt_e, opt_f, '--doFit', '--mcSig',  '--altBkg'])
     cmds.append(['python', ex, opt_e, opt_f, '--doFit',             '--altBkg'])
     cmds.append(['python', ex, opt_e, opt_f, '--sumUp'                        ])
@@ -93,11 +93,76 @@ working_points_new = {
     'mu_reco_plus': ['/scratch/rforti/steve_histograms_2016/reco/tnp_recoplus_mc_vertexWeights1_genMatching1_oscharge1.root',
                      '/scratch/rforti/steve_histograms_2016/reco/tnp_recoplus_data_vertexWeights1_genMatching1_oscharge1.root',
                      '/scratch/rforti/steve_histograms_2016/reco/tnp_recoplus_bkg_vertexWeights1_genMatching0_oscharge1.root'],
+    'mu_reco_minus': ['/scratch/rforti/steve_histograms_2016/reco/tnp_recominus_mc_vertexWeights1_genMatching1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2016/reco/tnp_recominus_data_vertexWeights1_genMatching1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2016/reco/tnp_recominus_bkg_vertexWeights1_genMatching0_oscharge1.root'],
     'mu_tracking_plus': ['/scratch/rforti/steve_histograms_2016/tracking/tnp_trackingplus_mc_vertexWeights1_genMatching1_oscharge0.root',
                          '/scratch/rforti/steve_histograms_2016/tracking/tnp_trackingplus_data_vertexWeights1_genMatching1_oscharge0.root',
-                          '/scratch/rforti/steve_histograms_2016/tracking/tnp_trackingplus_bkg_vertexWeights1_genMatching0_oscharge0.root'],
+                         '/scratch/rforti/steve_histograms_2016/tracking/tnp_trackingplus_bkg_vertexWeights1_genMatching0_oscharge0.root'],
+    'mu_tracking_minus': ['/scratch/rforti/steve_histograms_2016/tracking/tnp_trackingminus_mc_vertexWeights1_genMatching1_oscharge0.root',
+                          '/scratch/rforti/steve_histograms_2016/tracking/tnp_trackingminus_data_vertexWeights1_genMatching1_oscharge0.root',
+                          '/scratch/rforti/steve_histograms_2016/tracking/tnp_trackingminus_bkg_vertexWeights1_genMatching0_oscharge0.root'],
 }
 
+working_points_2017 = {
+    'mu_reco_plus': ['/scratch/rforti/steve_histograms_2017/tnp_recoplus_mc_vertexWeights1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2017/tnp_recoplus_data_vertexWeights1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2017/tnp_recoplus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_reco_minus': ['/scratch/rforti/steve_histograms_2017/tnp_recominus_mc_vertexWeights1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2017/tnp_recominus_data_vertexWeights1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2017/tnp_recominus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_tracking_plus': ['/scratch/rforti/steve_histograms_2017/tnp_trackingplus_mc_vertexWeights1_oscharge0.root',
+                         '/scratch/rforti/steve_histograms_2017/tnp_trackingplus_data_vertexWeights1_oscharge0.root',
+                         '/scratch/rforti/steve_histograms_2017/tnp_trackingplus_bkg_vertexWeights1_oscharge0.root'],
+    'mu_tracking_minus': ['/scratch/rforti/steve_histograms_2017/tnp_trackingminus_mc_vertexWeights1_oscharge0.root',
+                          '/scratch/rforti/steve_histograms_2017/tnp_trackingminus_data_vertexWeights1_oscharge0.root',
+                          '/scratch/rforti/steve_histograms_2017/tnp_trackingminus_bkg_vertexWeights1_oscharge0.root'],
+    'mu_idip_plus': ['/scratch/rforti/steve_histograms_2017/tnp_idipplus_mc_vertexWeights1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2017/tnp_idipplus_data_vertexWeights1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2017/tnp_idipplus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_idip_minus': ['/scratch/rforti/steve_histograms_2017/tnp_idipminus_mc_vertexWeights1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2017/tnp_idipminus_data_vertexWeights1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2017/tnp_idipminus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_trigger_plus': ['/scratch/rforti/steve_histograms_2017/tnp_triggerplus_mc_vertexWeights1_oscharge1.root',
+                        '/scratch/rforti/steve_histograms_2017/tnp_triggerplus_data_vertexWeights1_oscharge1.root',
+                        '/scratch/rforti/steve_histograms_2017/tnp_triggerplus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_trigger_minus': ['/scratch/rforti/steve_histograms_2017/tnp_triggerminus_mc_vertexWeights1_oscharge1.root',
+                         '/scratch/rforti/steve_histograms_2017/tnp_triggerminus_data_vertexWeights1_oscharge1.root',
+                         '/scratch/rforti/steve_histograms_2017/tnp_triggerminus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_iso_both': ['/scratch/rforti/steve_histograms_2017/tnp_iso_mc_vertexWeights1_oscharge1.root',
+                    '/scratch/rforti/steve_histograms_2017/tnp_iso_data_vertexWeights1_oscharge1.root',
+                    '/scratch/rforti/steve_histograms_2017/tnp_iso_bkg_vertexWeights1_oscharge1.root'],
+}
+
+working_points_2018 = {
+    'mu_reco_plus': ['/scratch/rforti/steve_histograms_2018/tnp_recoplus_mc_vertexWeights1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2018/tnp_recoplus_data_vertexWeights1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2018/tnp_recoplus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_reco_minus': ['/scratch/rforti/steve_histograms_2018/tnp_recominus_mc_vertexWeights1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2018/tnp_recominus_data_vertexWeights1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2018/tnp_recominus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_tracking_plus': ['/scratch/rforti/steve_histograms_2018/tnp_trackingplus_mc_vertexWeights1_oscharge0.root',
+                         '/scratch/rforti/steve_histograms_2018/tnp_trackingplus_data_vertexWeights1_oscharge0.root',
+                         '/scratch/rforti/steve_histograms_2018/tnp_trackingplus_bkg_vertexWeights1_oscharge0.root'],
+    'mu_tracking_minus': ['/scratch/rforti/steve_histograms_2018/tnp_trackingminus_mc_vertexWeights1_oscharge0.root',
+                          '/scratch/rforti/steve_histograms_2018/tnp_trackingminus_data_vertexWeights1_oscharge0.root',
+                          '/scratch/rforti/steve_histograms_2018/tnp_trackingminus_bkg_vertexWeights1_oscharge0.root'],
+    'mu_idip_plus': ['/scratch/rforti/steve_histograms_2018/tnp_idipplus_mc_vertexWeights1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2018/tnp_idipplus_data_vertexWeights1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2018/tnp_idipplus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_idip_minus': ['/scratch/rforti/steve_histograms_2018/tnp_idipminus_mc_vertexWeights1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2018/tnp_idipminus_data_vertexWeights1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2018/tnp_idipminus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_trigger_plus': ['/scratch/rforti/steve_histograms_2018/tnp_triggerplus_mc_vertexWeights1_oscharge1.root',
+                        '/scratch/rforti/steve_histograms_2018/tnp_triggerplus_data_vertexWeights1_oscharge1.root',
+                        '/scratch/rforti/steve_histograms_2018/tnp_triggerplus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_trigger_minus': ['/scratch/rforti/steve_histograms_2018/tnp_triggerminus_mc_vertexWeights1_oscharge1.root',
+                         '/scratch/rforti/steve_histograms_2018/tnp_triggerminus_data_vertexWeights1_oscharge1.root',
+                         '/scratch/rforti/steve_histograms_2018/tnp_triggerminus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_iso_both': ['/scratch/rforti/steve_histograms_2018/tnp_iso_mc_vertexWeights1_oscharge1.root',
+                    '/scratch/rforti/steve_histograms_2018/tnp_iso_data_vertexWeights1_oscharge1.root',
+                    '/scratch/rforti/steve_histograms_2018/tnp_iso_bkg_vertexWeights1_oscharge1.root'],
+}
 
 working_points_tracker = {
     'mu_reco_both': ['/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/trackerMuons_highPurity_allWP/tnp_reco_mc_vertexWeights1_oscharge1.root',
@@ -123,6 +188,7 @@ parser.add_argument('-o',  '--outdir', default=None, type=str,
                     help='name of the output folder (if not passed, a default one is used, which has the time stamp in it)')
 parser.add_argument('-e',  '--era', default=['GtoH'], nargs='+', type=str, choices=['GtoH', 'BtoF'],
                     help='Choose the era')
+parser.add_argument("-y", "--year", type=str, choices=["2016", "2017", "2018"], help="Year of data taking")
 parser.add_argument('-d',  '--dryRun', action='store_true',
                     help='Do not execute commands, just print them')
 parser.add_argument('-s','--steps', default=None, nargs='*', type=str, choices=list([x.split("_")[1] for x in working_points_global.keys()]),
@@ -143,7 +209,16 @@ if args.exclude and args.steps:
 
 eras = args.era
 #working_points = working_points_tracker if args.useTrackerMuons else working_points_global
-working_points = working_points_tracker if args.useTrackerMuons else working_points_new
+
+if args.useTrackerMuons:
+    working_points = working_points_tracker  
+else:
+    if args.year=="2017" :
+        working_points = working_points_2017
+    elif args.year=="2018" :
+        working_points = working_points_2018
+    else:
+        working_points = working_points_global
 
 
 stepsToRun = []

--- a/runFits.py
+++ b/runFits.py
@@ -28,7 +28,7 @@ def runCommands(wp, era, inputMC, inputData, options, inputBkg=None):
     cmds.append(['python', ex, opt_e, opt_f, '--doFit', '--mcSig'                        ])
     cmds.append(['python', ex, opt_e, opt_f, '--doFit', '--mcSig',  '--altSig'])
     cmds.append(['python', ex, opt_e, opt_f, '--doFit',             '--altSig'])
-    cmds.append(['python', ex, opt_e, opt_f, '--doFit', '--mcSig',  '--altBkg'])
+    #cmds.append(['python', ex, opt_e, opt_f, '--doFit', '--mcSig',  '--altBkg'])
     cmds.append(['python', ex, opt_e, opt_f, '--doFit',             '--altBkg'])
     cmds.append(['python', ex, opt_e, opt_f, '--sumUp'                        ])
 

--- a/runFits.py
+++ b/runFits.py
@@ -23,7 +23,10 @@ def runCommands(wp, era, inputMC, inputData, options, inputBkg=None):
     cmds = []
     ex = 'tnpEGM_fitter.py'
     cmds.append(['python', ex, opt_e, opt_f, '--createBins'                   ])
-    cmds.append(['python', ex, opt_e, opt_f, opt_iMC , opt_iData, opt_iBkg, '--createHists'])
+    if inputBkg:
+        cmds.append(['python', ex, opt_e, opt_f, opt_iMC , opt_iData, opt_iBkg, '--createHists'])
+    else:
+        cmds.append(['python', ex, opt_e, opt_f, opt_iMC , opt_iData, '--createHists'])
     cmds.append(['python', ex, opt_e, opt_f, '--doFit',                        ])
     cmds.append(['python', ex, opt_e, opt_f, '--doFit', '--mcSig'                        ])
     cmds.append(['python', ex, opt_e, opt_f, '--doFit', '--mcSig',  '--altSig'])
@@ -89,7 +92,7 @@ working_points_global = {
                      '/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_veto_data_vertexWeights1_oscharge1.root'],
 }
 
-working_points_new = {
+working_points_veto = {
     'mu_reco_plus': ['/scratch/rforti/steve_histograms_2016/reco/tnp_recoplus_mc_vertexWeights1_genMatching1_oscharge1.root',
                      '/scratch/rforti/steve_histograms_2016/reco/tnp_recoplus_data_vertexWeights1_genMatching1_oscharge1.root',
                      '/scratch/rforti/steve_histograms_2016/reco/tnp_recoplus_bkg_vertexWeights1_genMatching0_oscharge1.root'],
@@ -132,7 +135,10 @@ working_points_2017 = {
     'mu_iso_both': ['/scratch/rforti/steve_histograms_2017/tnp_iso_mc_vertexWeights1_oscharge1.root',
                     '/scratch/rforti/steve_histograms_2017/tnp_iso_data_vertexWeights1_oscharge1.root',
                     '/scratch/rforti/steve_histograms_2017/tnp_iso_bkg_vertexWeights1_oscharge1.root'],
-}
+    'mu_isonotrig_both': ['/scratch/rforti/steve_histograms_2017/tnp_isonotrig_mc_vertexWeights1_oscharge1.root',
+                          '/scratch/rforti/steve_histograms_2017/tnp_isonotrig_data_vertexWeights1_oscharge1.root',
+                          '/scratch/rforti/steve_histograms_2017/tnp_isonotrig_bkg_vertexWeights1_oscharge1.root'],
+    }
 
 working_points_2018 = {
     'mu_reco_plus': ['/scratch/rforti/steve_histograms_2018/tnp_recoplus_mc_vertexWeights1_oscharge1.root',
@@ -162,8 +168,52 @@ working_points_2018 = {
     'mu_iso_both': ['/scratch/rforti/steve_histograms_2018/tnp_iso_mc_vertexWeights1_oscharge1.root',
                     '/scratch/rforti/steve_histograms_2018/tnp_iso_data_vertexWeights1_oscharge1.root',
                     '/scratch/rforti/steve_histograms_2018/tnp_iso_bkg_vertexWeights1_oscharge1.root'],
+    'mu_isonotrig_both': ['/scratch/rforti/steve_histograms_2018/tnp_isonotrig_mc_vertexWeights1_oscharge1.root',
+                          '/scratch/rforti/steve_histograms_2018/tnp_isonotrig_data_vertexWeights1_oscharge1.root',
+                          '/scratch/rforti/steve_histograms_2018/tnp_isonotrig_bkg_vertexWeights1_oscharge1.root']
 }
 
+working_points_2017_forVeto = {
+    'mu_reco_plus': ['/scratch/rforti/steve_histograms_2017/forVeto/tnp_recoplus_mc_vertexWeights1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2017/forVeto/tnp_recoplus_data_vertexWeights1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2017/forVeto/tnp_recoplus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_reco_minus': ['/scratch/rforti/steve_histograms_2017/forVeto/tnp_recominus_mc_vertexWeights1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2017/forVeto/tnp_recominus_data_vertexWeights1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2017/forVeto/tnp_recominus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_tracking_plus': ['/scratch/rforti/steve_histograms_2017/forVeto/tnp_trackingplus_mc_vertexWeights1_oscharge0.root',
+                     '/scratch/rforti/steve_histograms_2017/forVeto/tnp_trackingplus_data_vertexWeights1_oscharge0.root',
+                     '/scratch/rforti/steve_histograms_2017/forVeto/tnp_trackingplus_bkg_vertexWeights1_oscharge0.root'],
+    'mu_tracking_minus': ['/scratch/rforti/steve_histograms_2017/forVeto/tnp_trackingminus_mc_vertexWeights1_oscharge0.root',
+                      '/scratch/rforti/steve_histograms_2017/forVeto/tnp_trackingminus_data_vertexWeights1_oscharge0.root',
+                      '/scratch/rforti/steve_histograms_2017/forVeto/tnp_trackingminus_bkg_vertexWeights1_oscharge0.root'],
+    'mu_veto_plus': ['/scratch/rforti/steve_histograms_2017/forVeto/tnp_vetoplus_mc_vertexWeights1_oscharge1.root',
+                    '/scratch/rforti/steve_histograms_2017/forVeto/tnp_vetoplus_data_vertexWeights1_oscharge1.root',
+                    '/scratch/rforti/steve_histograms_2017/forVeto/tnp_vetoplus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_veto_minus': ['/scratch/rforti/steve_histograms_2017/forVeto/tnp_vetominus_mc_vertexWeights1_oscharge1.root',
+                    '/scratch/rforti/steve_histograms_2017/forVeto/tnp_vetominus_data_vertexWeights1_oscharge1.root',
+                    '/scratch/rforti/steve_histograms_2017/forVeto/tnp_vetominus_bkg_vertexWeights1_oscharge1.root']
+}
+
+working_points_2018_forVeto = {
+    'mu_reco_plus': ['/scratch/rforti/steve_histograms_2018/forVeto/tnp_recoplus_mc_vertexWeights1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2018/forVeto/tnp_recoplus_data_vertexWeights1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2018/forVeto/tnp_recoplus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_reco_minus': ['/scratch/rforti/steve_histograms_2018/forVeto/tnp_recominus_mc_vertexWeights1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2018/forVeto/tnp_recominus_data_vertexWeights1_oscharge1.root',
+                      '/scratch/rforti/steve_histograms_2018/forVeto/tnp_recominus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_tracking_plus': ['/scratch/rforti/steve_histograms_2018/forVeto/tnp_trackingplus_mc_vertexWeights1_oscharge0.root',
+                     '/scratch/rforti/steve_histograms_2018/forVeto/tnp_trackingplus_data_vertexWeights1_oscharge0.root',
+                     '/scratch/rforti/steve_histograms_2018/forVeto/tnp_trackingplus_bkg_vertexWeights1_oscharge0.root'],
+    'mu_tracking_minus': ['/scratch/rforti/steve_histograms_2018/forVeto/tnp_trackingminus_mc_vertexWeights1_oscharge0.root',
+                      '/scratch/rforti/steve_histograms_2018/forVeto/tnp_trackingminus_data_vertexWeights1_oscharge0.root',
+                      '/scratch/rforti/steve_histograms_2018/forVeto/tnp_trackingminus_bkg_vertexWeights1_oscharge0.root'],
+    'mu_veto_plus': ['/scratch/rforti/steve_histograms_2018/forVeto/tnp_vetoplus_mc_vertexWeights1_oscharge1.root',
+                    '/scratch/rforti/steve_histograms_2018/forVeto/tnp_vetoplus_data_vertexWeights1_oscharge1.root',
+                    '/scratch/rforti/steve_histograms_2018/forVeto/tnp_vetoplus_bkg_vertexWeights1_oscharge1.root'],
+    'mu_veto_minus': ['/scratch/rforti/steve_histograms_2018/forVeto/tnp_vetominus_mc_vertexWeights1_oscharge1.root',
+                    '/scratch/rforti/steve_histograms_2018/forVeto/tnp_vetominus_data_vertexWeights1_oscharge1.root',
+                    '/scratch/rforti/steve_histograms_2018/forVeto/tnp_vetominus_bkg_vertexWeights1_oscharge1.root']
+}
 working_points_tracker = {
     'mu_reco_both': ['/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/trackerMuons_highPurity_allWP/tnp_reco_mc_vertexWeights1_oscharge1.root',
                      '/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/trackerMuons_highPurity_allWP/tnp_reco_data_vertexWeights1_oscharge1.root'],
@@ -188,13 +238,14 @@ parser.add_argument('-o',  '--outdir', default=None, type=str,
                     help='name of the output folder (if not passed, a default one is used, which has the time stamp in it)')
 parser.add_argument('-e',  '--era', default=['GtoH'], nargs='+', type=str, choices=['GtoH', 'BtoF'],
                     help='Choose the era')
-parser.add_argument("-y", "--year", type=str, choices=["2016", "2017", "2018"], help="Year of data taking")
+parser.add_argument("-y", "--year", type=str, default="2016", choices=["2016", "2017", "2018"], help="Year of data taking")
 parser.add_argument('-d',  '--dryRun', action='store_true',
                     help='Do not execute commands, just print them')
 parser.add_argument('-s','--steps', default=None, nargs='*', type=str, choices=list([x.split("_")[1] for x in working_points_global.keys()]),
                     help='Default runs all working points, but can choose only some if needed')
 parser.add_argument('-x','--exclude', default=None, nargs='*', type=str, choices=list([x.split("_")[1] for x in working_points_global.keys()]),
                     help='Default runs all working points, but can exclude some if needed')
+parser.add_argument('--forVeto', action='store_true', help='Use the working points related to veto')               
 parser.add_argument('--useTrackerMuons', action='store_true'  , help = 'Measuring efficiencies specific for tracker muons (different tunings needed')
 parser.add_argument('--onlySumUp', action='store_true',
                     help='Execute only the final command with --sumUp')
@@ -214,9 +265,9 @@ if args.useTrackerMuons:
     working_points = working_points_tracker  
 else:
     if args.year=="2017" :
-        working_points = working_points_2017
+        working_points = working_points_2017 if not args.forVeto else working_points_2017_forVeto
     elif args.year=="2018" :
-        working_points = working_points_2018
+        working_points = working_points_2018 if not args.forVeto else working_points_2018_forVeto
     else:
         working_points = working_points_global
 
@@ -247,6 +298,7 @@ for e in eras:
             inputBkg = working_points[wp][2]
         else:
             inputBkg = None
+        print(inputBkg)
         runCommands( wp, e, inputMC, inputData, args, inputBkg=inputBkg)
 
 elapsed = time.time() - tstart

--- a/runFits.py
+++ b/runFits.py
@@ -22,15 +22,15 @@ def runCommands(wp, era, inputMC, inputData, options, inputBkg=None):
         opt_iBkg = ''
     cmds = []
     ex = 'tnpEGM_fitter.py'
-    cmds.append(['python3', ex, opt_e, opt_f, '--createBins'                   ])
-    cmds.append(['python3', ex, opt_e, opt_f, opt_iMC , opt_iData , '--createHists'])
-    #cmds.append(['python', ex, opt_e, opt_f, '--doFit',                        ])
-    #cmds.append(['python', ex, opt_e, opt_f, '--doFit', '--mcSig'                        ])
-    #cmds.append(['python', ex, opt_e, opt_f, '--doFit', '--mcSig',  '--altSig'])
-    #cmds.append(['python', ex, opt_e, opt_f, '--doFit',             '--altSig'])
-    #cmds.append(['python', ex, opt_e, opt_f, '--doFit', '--mcSig',  '--altBkg'])
-    cmds.append(['python3', ex, opt_e, opt_f, '--doFit',             '--altBkg'])
-    cmds.append(['python3', ex, opt_e, opt_f, '--sumUp'                        ])
+    cmds.append(['python', ex, opt_e, opt_f, '--createBins'                   ])
+    cmds.append(['python', ex, opt_e, opt_f, opt_iMC , opt_iData, opt_iBkg, '--createHists'])
+    cmds.append(['python', ex, opt_e, opt_f, '--doFit',                        ])
+    cmds.append(['python', ex, opt_e, opt_f, '--doFit', '--mcSig'                        ])
+    cmds.append(['python', ex, opt_e, opt_f, '--doFit', '--mcSig',  '--altSig'])
+    cmds.append(['python', ex, opt_e, opt_f, '--doFit',             '--altSig'])
+    cmds.append(['python', ex, opt_e, opt_f, '--doFit', '--mcSig',  '--altBkg'])
+    cmds.append(['python', ex, opt_e, opt_f, '--doFit',             '--altBkg'])
+    cmds.append(['python', ex, opt_e, opt_f, '--sumUp'                        ])
 
     for cmd in cmds:
         if args.onlySumUp and "--sumUp" not in cmd:
@@ -90,9 +90,9 @@ working_points_global = {
 }
 
 working_points_new = {
-    'mu_reco_plus': ['steve_histograms_2016/reco/tnp_recoplus_mc_vertexWeights1_genMatching1_oscharge1.root',
-                     'steve_histograms_2016/reco/tnp_recoplus_data_vertexWeights1_genMatching1_oscharge1.root',
-                     'steve_histograms_2016/reco/tnp_recoplus_bkg_vertexWeights1_genMatching0_oscharge1.root'],
+    'mu_reco_plus': ['/scratch/rforti/steve_histograms_2016/reco/tnp_recoplus_mc_vertexWeights1_genMatching1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2016/reco/tnp_recoplus_data_vertexWeights1_genMatching1_oscharge1.root',
+                     '/scratch/rforti/steve_histograms_2016/reco/tnp_recoplus_bkg_vertexWeights1_genMatching0_oscharge1.root'],
 }
 
 

--- a/runFits.py
+++ b/runFits.py
@@ -5,7 +5,7 @@ import subprocess
 import time
 import argparse
 
-def runCommands(wp, era, inputMC, inputData, options):
+def runCommands(wp, era, inputMC, inputData, options, inputBkg=None):
     outdir = options.outdir
     pretend = options.dryRun
     print()
@@ -16,17 +16,21 @@ def runCommands(wp, era, inputMC, inputData, options):
     opt_f = '--flag='+wp
     opt_iMC = '--inputMC='+inputMC
     opt_iData = '--inputData='+inputData
+    if inputBkg:
+        opt_iBkg = '--inputBkg='+inputBkg
+    else:
+        opt_iBkg = ''
     cmds = []
     ex = 'tnpEGM_fitter.py'
-    cmds.append(['python', ex, opt_e, opt_f, '--createBins'                   ])
-    cmds.append(['python', ex, opt_e, opt_f, opt_iMC , opt_iData , '--createHists'])
-    cmds.append(['python', ex, opt_e, opt_f, '--doFit',                        ])
+    cmds.append(['python3', ex, opt_e, opt_f, '--createBins'                   ])
+    cmds.append(['python3', ex, opt_e, opt_f, opt_iMC , opt_iData , '--createHists'])
+    #cmds.append(['python', ex, opt_e, opt_f, '--doFit',                        ])
     #cmds.append(['python', ex, opt_e, opt_f, '--doFit', '--mcSig'                        ])
-    cmds.append(['python', ex, opt_e, opt_f, '--doFit', '--mcSig',  '--altSig'])
-    cmds.append(['python', ex, opt_e, opt_f, '--doFit',             '--altSig'])
+    #cmds.append(['python', ex, opt_e, opt_f, '--doFit', '--mcSig',  '--altSig'])
+    #cmds.append(['python', ex, opt_e, opt_f, '--doFit',             '--altSig'])
     #cmds.append(['python', ex, opt_e, opt_f, '--doFit', '--mcSig',  '--altBkg'])
-    #cmds.append(['python', ex, opt_e, opt_f, '--doFit',             '--altBkg'])
-    cmds.append(['python', ex, opt_e, opt_f, '--sumUp'                        ])
+    cmds.append(['python3', ex, opt_e, opt_f, '--doFit',             '--altBkg'])
+    cmds.append(['python3', ex, opt_e, opt_f, '--sumUp'                        ])
 
     for cmd in cmds:
         if args.onlySumUp and "--sumUp" not in cmd:
@@ -85,6 +89,13 @@ working_points_global = {
                      '/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/test_globalMuons_highPurity_XYZ_1orMoreValidHitsSA/tnp_veto_data_vertexWeights1_oscharge1.root'],
 }
 
+working_points_new = {
+    'mu_reco_plus': ['steve_histograms_2016/reco/tnp_recoplus_mc_vertexWeights1_genMatching1_oscharge1.root',
+                     'steve_histograms_2016/reco/tnp_recoplus_data_vertexWeights1_genMatching1_oscharge1.root',
+                     'steve_histograms_2016/reco/tnp_recoplus_bkg_vertexWeights1_genMatching0_oscharge1.root'],
+}
+
+
 working_points_tracker = {
     'mu_reco_both': ['/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/trackerMuons_highPurity_allWP/tnp_reco_mc_vertexWeights1_oscharge1.root',
                      '/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/trackerMuons_highPurity_allWP/tnp_reco_data_vertexWeights1_oscharge1.root'],
@@ -103,7 +114,6 @@ working_points_tracker = {
     'mu_veto_both': ['/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/trackerMuons_highPurity_allWP/tnp_veto_mc_vertexWeights1_oscharge1.root',
                      '/home/m/mciprian/tnp/Steve_Marc_Raj/outputs/trackerMuons_highPurity_allWP/tnp_veto_data_vertexWeights1_oscharge1.root'],
 }
-
 
 parser = argparse.ArgumentParser()
 parser.add_argument('-o',  '--outdir', default=None, type=str,
@@ -129,7 +139,9 @@ if args.exclude and args.steps:
     quit()
 
 eras = args.era
-working_points = working_points_tracker if args.useTrackerMuons else working_points_global
+#working_points = working_points_tracker if args.useTrackerMuons else working_points_global
+working_points = working_points_tracker if args.useTrackerMuons else working_points_new
+
 
 stepsToRun = []
 if args.steps:
@@ -153,7 +165,11 @@ for e in eras:
             continue
         inputMC = working_points[wp][0]
         inputData = working_points[wp][1]
-        runCommands( wp, e, inputMC, inputData, args)
+        if len(working_points[wp]) == 3:
+            inputBkg = working_points[wp][2]
+        else:
+            inputBkg = None
+        runCommands( wp, e, inputMC, inputData, args, inputBkg=inputBkg)
 
 elapsed = time.time() - tstart
 elapsed_cpu = time.process_time() - cpustrat

--- a/tnpEGM_fitter.py
+++ b/tnpEGM_fitter.py
@@ -153,6 +153,11 @@ if typeflag == 'tracking':
         "meanP[-0.0,-5.0,5.0]","sigmaP[1,0.7,6.0]","alphaP[2.0,1.2,3.5]",'nP[3,0.01,5]',"sigmaP_2[1.5,0.5,6.0]",
         "meanF[-0.0,-12.0,12.0]","sigmaF[2,0.7,12.0]","alphaF[2.0,1.2,3.5]",'nF[3,0.01,5]',"sigmaF_2[2.0,0.5,6.0]",
     ]
+    
+    tnpParAltBkgFit = [
+        "meanP[-0.0,-5.0,5.0]", "sigmaP[0.5,0.1,5.0]", "expalphaP[0.,-5.,5.]",
+        "meanF[-0.0,-5.0,5.0]", "sigmaF[0.5,0.02,3.0]",
+    ]
 
     # for pt >= 55 and tracking (se also note above)
     tnpParAltSigFitTrackingHighPt = [
@@ -220,6 +225,11 @@ elif typeflag == 'reco':
         "meanP[-0.0,-5.0,5.0]","sigmaP[1,0.7,6.0]","alphaP[2.0,1.2,3.5]",'nP[3,0.01,5]',"sigmaP_2[1.5,0.5,6.0]",
         "meanF[-0.0,-5.0,5.0]","sigmaF[2,0.7,5.0]","alphaF[2.0,1.2,3.5]",'nF[3,0.1,5]',"sigmaF_2[2.0,0.5,6.0]",
     ]
+    
+    tnpParAltBkgFit = [
+        "meanP[-0.0,-5.0,5.0]", "sigmaP[0.5,0.1,3.0]", "expalphaP[0.,-5.,5.]",
+        "meanF[-0.0,-3.0,3.0]", "sigmaF[0.5,0.01,2.0]",
+    ]
 
     tnpParNomFit.extend(bkgParFit)
     tnpParAltSigFit.extend(bkgParFit)
@@ -262,6 +272,11 @@ else:
         "meanF[-0.0,-5.0,5.0]","sigmaF[0.5,0.1,5.0]",
     ]
     
+    tnpParAltBkgFit = [
+        "meanP[-0.0,-5.0,5.0]","sigmaP[0.5,0.1,5.0]", "expalphaP[0.,-5.,5.]",
+        "meanF[-0.0,-5.0,5.0]","sigmaF[0.5,0.1,5.0]",
+    ]
+    
     tnpParAltSigFit = [
         "meanP[-0.0,-5.0,5.0]","sigmaP[1,0.7,6.0]","alphaP[2.0,1.2,3.5]",'nP[3,0.01,5]',"sigmaP_2[1.5,0.5,6.0]",
         "meanF[-0.0,-5.0,5.0]","sigmaF[2,0.7,15.0]","alphaF[2.0,1.2,3.5]",'nF[3,0.01,5]',"sigmaF_2[2.0,0.5,6.0]",
@@ -278,20 +293,6 @@ if any(x in typeflag for x in flagsWithFSR):
     fsrGauss = ["fsrMeanF[70.0,65.0,80.0]", "fsrSigmaF[1.0,1.2,5.0]"]
     tnpParAltSigFit.extend(fsrGauss)
 
-# for now this is not used, the nominal background model has been moved to exponential already, this might become a Bernstein polynominal or something
-tnpParAltBkgFit = [
-    "meanP[-0.0,-5.0,5.0]","sigmaP[0.5,0.01,5.0]",
-    "meanF[-0.0,-3.0,3.0]","sigmaF[0.5,0.02,3.0]",
-    "expalphaP[0.,-5.,5.]",
-    #"expalphaF[0.,-5.,5.]",
-    ]
-'''
-bkgShapesAltBkg = [
-    "Exponential::bkgPass(x, expalphaP)",
-    "RooHistPdf::bkgFail(x, hTotBkgFail, 0)",
-    "RooHistPdf::bkgFailBackup(x, hTotBkgFail, 0)",
-]
-'''
 
 if args.outdir:
     baseOutDir = '{o}/efficiencies_{era}/'.format(o=args.outdir, era=args.era)
@@ -479,7 +480,7 @@ if  args.doFit:
                 # do this only for data
                 if args.altBkg:
                     fitUtils.histFitterAltBkgTemplate(sampleToFit, tnpBins['bins'][ib], tnpParAltBkgFit, massbins, massmin, massmax,
-                                                      useAllTemplateForFail, maxFailIntegralToUseAllProbe, constrainPars=parConstraints, bkgShapes=[], isBBfail=False)
+                                                      useAllTemplateForFail, maxFailIntegralToUseAllProbe, constrainPars=parConstraints, bkgShapes=[], isBBfail=True)
                 else:
                     fitUtils.histFitterNominal(sampleToFit, tnpBins['bins'][ib], tnpParNomFit, massbins, massmin, massmax,
                                                useAllTemplateForFail, maxFailIntegralToUseAllProbe, constrainPars=parConstraints, bkgShapes=bkgShapes)

--- a/tnpEGM_fitter.py
+++ b/tnpEGM_fitter.py
@@ -183,10 +183,10 @@ if typeflag == 'tracking':
         #"Gaussian::constrainP_betaP(betaP,0.05,0.25)",
         #"Gaussian::constrainP_gammaP(gammaP,0.5,0.8)",
         # failing
-        "Gaussian::constrainF_acmsF(acmsF,90,50)",
+        #"Gaussian::constrainF_acmsF(acmsF,90,50)",
         #"Gaussian::constrainF_betaF(betaF,0.05,0.25)",
-        "Gaussian::constrainF_betaF(betaF,5.0,25.0)",
-        "Gaussian::constrainF_gammaF(gammaF,0.5,0.8)",
+        #"Gaussian::constrainF_betaF(betaF,5.0,25.0)",
+        #"Gaussian::constrainF_gammaF(gammaF,0.5,0.8)",
     ]
 
             
@@ -479,7 +479,7 @@ if  args.doFit:
                 # do this only for data
                 if args.altBkg:
                     fitUtils.histFitterAltBkgTemplate(sampleToFit, tnpBins['bins'][ib], tnpParAltBkgFit, massbins, massmin, massmax,
-                                                      useAllTemplateForFail, maxFailIntegralToUseAllProbe, constrainPars=parConstraints, bkgShapes=[], isBBfail=True)
+                                                      useAllTemplateForFail, maxFailIntegralToUseAllProbe, constrainPars=parConstraints, bkgShapes=[], isBBfail=False)
                 else:
                     fitUtils.histFitterNominal(sampleToFit, tnpBins['bins'][ib], tnpParNomFit, massbins, massmin, massmax,
                                                useAllTemplateForFail, maxFailIntegralToUseAllProbe, constrainPars=parConstraints, bkgShapes=bkgShapes)
@@ -490,7 +490,7 @@ if  args.doFit:
 
     pool = Pool() ## parallel
     pool.map(parallel_fit, range(len(tnpBins['bins']))) ## parallel
-    #parallel_fit(421)
+    #parallel_fit(0)
     args.doPlot = True
 
 ####################################################################

--- a/tnpEGM_fitter.py
+++ b/tnpEGM_fitter.py
@@ -85,7 +85,7 @@ if typeflag == 'tracking':
     #binning_pt  = [15., 25.,35.,45.,55.,65.,80.]
     #massbins, massmin, massmax = 100, 40, 140
     #binning_pt  = [55., 65.]
-    binning_pt  = [24., 35., 45., 55., 65.]  # [24., 65.]
+    binning_pt  = [10., 15., 24., 35., 45., 55., 65.]  # [24., 65.]
     #massbins, massmin, massmax = 100, 50, 150
     massbins, massmin, massmax = 80, 50, 130
     binningDef = {
@@ -100,7 +100,7 @@ elif typeflag == 'reco':
     if args.useTrackerMuons:
         binning_pt  = [24., 26., 30., 34., 38., 42., 46., 50., 55., 65.]
     else:
-        binning_pt  = [24., 26., 30., 34., 38., 42., 46., 50., 55., 60., 65.]
+        binning_pt  = [10., 15., 20., 24., 26., 30., 34., 38., 42., 46., 50., 55., 60., 65.]
     #binning_pt  = [24., 26., 28., 30., 32., 34., 36., 38., 40., 42., 44., 47., 50., 55., 60., 65.]
     binningDef = {
         'eta' : {'var' : 'eta', 'type': 'float', 'bins': binning_eta},
@@ -108,7 +108,8 @@ elif typeflag == 'reco':
     }
 
 elif typeflag == 'veto':
-    binning_pt = [(15. + 5.*i) for i in range(11)]
+    binning_pt  = [10., 15., 20., 24., 26., 28., 30., 32., 34., 36., 38., 40., 42., 44., 47., 50., 55., 60., 65.]
+    #binning_pt = [(15. + 5.*i) for i in range(11)]
     binningDef = {
         'eta' : {'var' : 'eta', 'type': 'float', 'bins': binning_eta},
         'pt'  : {'var' : 'pt' , 'type': 'float', 'bins': binning_pt }
@@ -188,10 +189,10 @@ if typeflag == 'tracking':
         #"Gaussian::constrainP_betaP(betaP,0.05,0.25)",
         #"Gaussian::constrainP_gammaP(gammaP,0.5,0.8)",
         # failing
-        #"Gaussian::constrainF_acmsF(acmsF,90,50)",
+        "Gaussian::constrainF_acmsF(acmsF,90,50)",
         #"Gaussian::constrainF_betaF(betaF,0.05,0.25)",
-        #"Gaussian::constrainF_betaF(betaF,5.0,25.0)",
-        #"Gaussian::constrainF_gammaF(gammaF,0.5,0.8)",
+        "Gaussian::constrainF_betaF(betaF,5.0,25.0)",
+        "Gaussian::constrainF_gammaF(gammaF,0.5,0.8)",
     ]
 
             
@@ -246,9 +247,9 @@ elif typeflag == 'reco':
         #"Gaussian::constrainP_betaP(betaP,0.05,0.25)",
         #"Gaussian::constrainP_gammaP(gammaP,0.5,0.8)",
         # failing
-        #"Gaussian::constrainF_acmsF(acmsF,90,50)",
-        #"Gaussian::constrainF_betaF(betaF,5.0,25.0)",
-        #"Gaussian::constrainF_gammaF(gammaF,0.5,0.8)",
+        "Gaussian::constrainF_acmsF(acmsF,90,50)",
+        "Gaussian::constrainF_betaF(betaF,5.0,25.0)",
+        "Gaussian::constrainF_gammaF(gammaF,0.5,0.8)",
     ]
 
 else:
@@ -318,12 +319,14 @@ samples_dy = tnpSample(mcName,
                        args.inputMC,
                        f"{outputDirectory}/{mcName}_{args.flag}.root",
                        True)
-
-bkg_name = f"mu_mcBkg_{eraMC}"
-samples_bkg = tnpSample(bkg_name,
-                        args.inputBkg,
-                        f"{outputDirectory}/{bkg_name}_{args.flag}.root",
-                        True)
+if args.inputBkg or args.altBkg:
+    bkg_name = f"mu_mcBkg_{eraMC}"
+    samples_bkg = tnpSample(bkg_name,
+                            args.inputBkg,
+                            f"{outputDirectory}/{bkg_name}_{args.flag}.root",
+                            True)
+else:
+    samples_bkg=None
 #samples_data.printConfig()
 #samples_dy.printConfig()
 
@@ -411,7 +414,7 @@ if args.createHists:
 ####################################################################
 ##### Actual Fitter
 ####################################################################
-sampleToFit = samplesDef['data']
+sampleToFit = samplesDef['data'] 
 if sampleToFit is None:
     print('[tnpEGM_fitter, prelim checks]: sample (data or MC) not available... check your settings')
     sys.exit(1)
@@ -446,7 +449,7 @@ if args.altBkg :
 plottingDir = '%s/plots/%s/%s' % (outputDirectory,sampleToFit.getName(),fitType)
 createPlotDirAndCopyPhp(plottingDir)
     
-if  args.doFit:
+if args.doFit:
     print(">>> running fits")
     #print('sampleToFit.dump()', sampleToFit.dump())
     # can't use all probes for cases with isolation, since the failing probe sample has the FSR and a second bump at low mass
@@ -480,7 +483,7 @@ if  args.doFit:
                 # do this only for data
                 if args.altBkg:
                     fitUtils.histFitterAltBkgTemplate(sampleToFit, tnpBins['bins'][ib], tnpParAltBkgFit, massbins, massmin, massmax,
-                                                      useAllTemplateForFail, maxFailIntegralToUseAllProbe, constrainPars=parConstraints, bkgShapes=[], isBBfail=True)
+                                                      useAllTemplateForFail, maxFailIntegralToUseAllProbe, constrainPars=[], bkgShapes=[], isBBfail=True)
                 else:
                     fitUtils.histFitterNominal(sampleToFit, tnpBins['bins'][ib], tnpParNomFit, massbins, massmin, massmax,
                                                useAllTemplateForFail, maxFailIntegralToUseAllProbe, constrainPars=parConstraints, bkgShapes=bkgShapes)

--- a/tnpEGM_fitter.py
+++ b/tnpEGM_fitter.py
@@ -236,9 +236,9 @@ elif typeflag == 'reco':
         #"Gaussian::constrainP_betaP(betaP,0.05,0.25)",
         #"Gaussian::constrainP_gammaP(gammaP,0.5,0.8)",
         # failing
-        "Gaussian::constrainF_acmsF(acmsF,90,50)",
-        "Gaussian::constrainF_betaF(betaF,5.0,25.0)",
-        "Gaussian::constrainF_gammaF(gammaF,0.5,0.8)",
+        #"Gaussian::constrainF_acmsF(acmsF,90,50)",
+        #"Gaussian::constrainF_betaF(betaF,5.0,25.0)",
+        #"Gaussian::constrainF_gammaF(gammaF,0.5,0.8)",
     ]
 
 else:
@@ -285,12 +285,13 @@ tnpParAltBkgFit = [
     "expalphaP[0.,-5.,5.]",
     #"expalphaF[0.,-5.,5.]",
     ]
-
+'''
 bkgShapesAltBkg = [
     "Exponential::bkgPass(x, expalphaP)",
     "RooHistPdf::bkgFail(x, hTotBkgFail, 0)",
     "RooHistPdf::bkgFailBackup(x, hTotBkgFail, 0)",
 ]
+'''
 
 if args.outdir:
     baseOutDir = '{o}/efficiencies_{era}/'.format(o=args.outdir, era=args.era)
@@ -478,7 +479,7 @@ if  args.doFit:
                 # do this only for data
                 if args.altBkg:
                     fitUtils.histFitterAltBkgTemplate(sampleToFit, tnpBins['bins'][ib], tnpParAltBkgFit, massbins, massmin, massmax,
-                                                      useAllTemplateForFail, maxFailIntegralToUseAllProbe, bkgShapes=bkgShapesAltBkg)
+                                                      useAllTemplateForFail, maxFailIntegralToUseAllProbe, constrainPars=parConstraints, bkgShapes=[], isBBfail=True)
                 else:
                     fitUtils.histFitterNominal(sampleToFit, tnpBins['bins'][ib], tnpParNomFit, massbins, massmin, massmax,
                                                useAllTemplateForFail, maxFailIntegralToUseAllProbe, constrainPars=parConstraints, bkgShapes=bkgShapes)
@@ -489,7 +490,7 @@ if  args.doFit:
 
     pool = Pool() ## parallel
     pool.map(parallel_fit, range(len(tnpBins['bins']))) ## parallel
-
+    #parallel_fit(421)
     args.doPlot = True
 
 ####################################################################

--- a/tnpEGM_fitter.py
+++ b/tnpEGM_fitter.py
@@ -567,6 +567,7 @@ if args.sumUp:
     #print('this is the dump of sampleToFit:')
     #sampleToFit.dump()
     #pprint(vars(sampleToFit.mcRef))
+
     #print('done with dump')
     info = {
         #'data'        : sampleToFit.getOutputPath(),
@@ -576,7 +577,7 @@ if args.sumUp:
         'mcNominal'   : sampleToFit.mcRef.getOutputPath(),
         'mcNominal_fit': sampleToFit.mcRef.nominalFit,
         'mcAltSig'    : sampleToFit.mcRef.altSigFit,
-        'mcAltBkg'    : sampleToFit.mcRef.altBkgFit,
+        'mcAltBkg'    : sampleToFit.mcRef.altBkgFit, # not used
         'tagSel'      : None
         }
 
@@ -589,13 +590,14 @@ if args.sumUp:
     #print(info)
 
     effFileName = outputDirectory+'/allEfficiencies.txt'
+
     # security check, if the code crashes the temporary files are still present, let's remove them before executing parallel_sumUp
     if any ("_tmpTMP_" in f for f in os.listdir(outputDirectory)):
         os.system(f"rm {effFileName}_tmpTMP_*")
             
     #fOut = open( effFileName,'w')
     def parallel_sumUp(_bin):
-        effis = tnpRoot.getAllEffi( info, _bin, outputDirectory, saveCanvas=True)
+        effis = tnpRoot.getAllEffi(info, _bin, outputDirectory, saveCanvas=True)
         #print("effis =",effis)
         #print('this is _bin', _bin)        
         ### formatting assuming 2D bining -- to be fixed
@@ -611,23 +613,27 @@ if args.sumUp:
             fOut.write( astr )
             astr = '### var2 : %s\n' % v2Range[1]
             fOut.write( astr )
-            exp = '{v0:8s}\t{v1:8s}\t{v2:8s}\t{v3:8s}\t{edv:10s}\t{ede:10s}\t{emcv:10s}\t{emce:10s}\t{edalts:15s}\t{edaltse:15s}\t{emcalt:15s}\t{emcalte:15s}\t{edaltb:15s}\t{etagsel:10s}\n'.format(
+            #exp = '{v0:8s}\t{v1:8s}\t{v2:8s}\t{v3:8s}\t{edaltb:10s}\t{edaltbe:10s}\t{emcv:10s}\t{emce:10s}\n'.format( 
+            exp = '{v0:8s}\t{v1:8s}\t{v2:8s}\t{v3:8s}\t{edv:10s}\t{ede:10s}\t{emcv:10s}\t{emce:10s}\t{edalts:15s}\t{edaltse:15s}\t{edaltb:15s}\t{edaltbe:15s}\t{emcalt:15s}\t{emcalte:15s}\t{etagsel:10s}\n'.format(
                 v0='var1min', v1='var1max', v2='var2min', v3='var2max',
                 edv='eff data', ede='err data',
                 emcv='eff mc', emce='err mc',
                 edalts='eff data altS', edaltse='err data altS',
-                emcalt='eff mc alt', emcalte='err mc alt', edaltb='eff data altB', etagsel='eff tag sel')
+                edaltb='eff data altB', edaltbe='err data altB',
+                emcalt='eff mc alt', emcalte='err mc alt',
+                etagsel='eff tag sel'
+                )
             #print(exp)
             fOut.write(exp)
 
-        astr =  '%-+8.3f\t%-+8.3f\t%-+8.3f\t%-+8.3f\t%-10.6f\t%-10.6f\t%-10.6f\t%-10.6f\t%-15.6f\t%-15.6f\t%-15.6f\t%-15.6f\t%-15.6f\t%-10.5f' % (
+        astr =  '%-+8.3f\t%-+8.3f\t%-+8.3f\t%-+8.3f\t%-10.6f\t%-10.6f\t%-10.6f\t%-10.6f\t%-15.6f\t%-15.6f\t%-15.6f\t%-15.6f\t%-15.6f\t%-15.6f\t%-10.5f' % (
             float(v1Range[0]), float(v1Range[2]),
             float(v2Range[0]), float(v2Range[2]),
             effis['dataNominal'][0],effis['dataNominal'][1],
             effis['mcNominal'  ][0],effis['mcNominal'  ][1],
             effis['dataAltSig' ][0],effis['dataAltSig' ][1],
+            effis['dataAltBkg' ][0], effis['dataAltBkg' ][1],
             effis['mcAltSig' ][0], effis['mcAltSig' ][1],
-            effis['dataAltBkg' ][0],
             effis['tagSel'][0],
             )
         #print(astr)


### PR DESCRIPTION
This PR contains some changes that allow to run the alternative background fits using a template extracted from MC predictions. Below are the most important changes.

### Import and use of the templates
* Defined sample for the bkg histograms in `tnpEGM.py`
* Created the function `histFitterAltBkgTemplate` in `libPython/fitUtils.py` to handle the specific options for the fit (it replaces the `histFitterAltBkg` function in `tnpEGM.py`). The Barlow-Beeston strategy can be activated by turning into True the argument `isBBfail` of this function
* Introduced methods `setTotalBkgShapes` and `setBarlowBeestonBkgPdf` in the `tnpFitter`


### Technical adjustments
* Some changes in `tnpFitter::manageFit` to run on ROOT 6.32 and to avoid parallelization of the minimization procedure for the single bins (see [release note](https://root.cern/doc/v632/release-notes.html#release-6.32.06)): without that correction, some instabilities in minimization convergence have been observed.
* The CMSShape pdf now is defined with an analytical integral. It has been seen that, without this feature, when running on the 'tracking' step, the minimization procedure wasn't able to end for some bins. This effect has been observed before the implementation of the correction explained previous point

### Other adjustments
* New file `create_totBkg_file.py` to produce the TH3D representative of the sum of the various bkg sources (scaled wrt data luminosity)
* The "main efficiency plots" produced by the standard procedure, those containing three types of efficiencies, now show the nominal fit together with the altSig and the altBkg ones. The fit on MC is not shown anymore, but the MC counting efficiency is reported below the nominal one